### PR TITLE
refactor(metal): allow ssh_key contents to be passed in by string

### DIFF
--- a/gradient-metal/common.tf
+++ b/gradient-metal/common.tf
@@ -124,11 +124,6 @@ variable "name" {
     description = "Name"
 }
 
-variable "public_key_path" {
-    description = "Login key path"
-    default = ""
-}
-
 variable "sentry_dsn" {
     description = "DSN for sentry alerts"
     default = ""

--- a/gradient-metal/input.tf
+++ b/gradient-metal/input.tf
@@ -20,12 +20,12 @@ variable "k8s_workers" {
 }
 
 variable "ssh_key" {
-    description = "SSH key_path"
+    description = "Private SSH key"
     default = ""
 }
 
 variable "ssh_key_path" {
-    description = "SSH key_path"
+    description = "Private SSH key file path"
     default = "~/.ssh/id_rsa"
 }
 

--- a/gradient-metal/main.tf
+++ b/gradient-metal/main.tf
@@ -23,8 +23,7 @@ module "kubernetes" {
     service_pool_name = local.service_pool_name
     setup_docker = var.setup_docker
     setup_nvidia = var.setup_nvidia
-    ssh_key = var.ssh_key
-    ssh_key_path = var.ssh_key_path
+    ssh_key_private = var.ssh_key == "" ? file(pathexpand(var.ssh_key_path)) : var.ssh_key
     ssh_user = var.ssh_user
     write_kubeconfig = var.write_kubeconfig
     workers = var.k8s_workers

--- a/gradient-metal/modules/kubernetes/input.tf
+++ b/gradient-metal/modules/kubernetes/input.tf
@@ -47,12 +47,8 @@ variable "service_pool_name" {
     description = "Service pool selector"
 }
 
-variable "ssh_key" {
-    description = "SSH key"
-}
-
-variable "ssh_key_path" {
-    description = "SSH key path"
+variable "ssh_key_private" {
+    description = "Private SSH key"
 }
 
 variable "ssh_user" {

--- a/gradient-metal/modules/kubernetes/main.tf
+++ b/gradient-metal/modules/kubernetes/main.tf
@@ -43,7 +43,7 @@ resource "null_resource" "rke_nodes_wait" {
             type     = "ssh"
             user     = var.ssh_user
             host     = local.rke_nodes[count.index].ip
-            private_key = file(pathexpand(var.ssh_key_path))
+            private_key = var.ssh_key_private
         }
     }
 
@@ -54,7 +54,7 @@ resource "null_resource" "rke_nodes_wait" {
             type     = "ssh"
             user     = var.ssh_user
             host     = local.rke_nodes[count.index].ip
-            private_key = file(pathexpand(var.ssh_key_path))
+            private_key = var.ssh_key_private
         }
     }
 
@@ -71,7 +71,7 @@ resource "null_resource" "rke_nodes_wait" {
             type     = "ssh"
             user     = var.ssh_user
             host     = local.rke_nodes[count.index].ip
-            private_key = file(pathexpand(var.ssh_key_path))
+            private_key = var.ssh_key_private
         }
     }
 
@@ -81,7 +81,7 @@ resource "null_resource" "rke_nodes_wait" {
             type     = "ssh"
             user     = var.ssh_user
             host     = local.rke_nodes[count.index].ip
-            private_key = file(pathexpand(var.ssh_key_path))
+            private_key = var.ssh_key_private
         }
     }
 }
@@ -99,7 +99,7 @@ resource "rke_cluster" "main" {
             docker_socket = var.docker_socket
             labels = nodes.value["labels"]
             role    = nodes.value["roles"]
-            ssh_key = file(var.ssh_key_path)
+            ssh_key = var.ssh_key_private
             user    = var.ssh_user
         }
     }


### PR DESCRIPTION
Expands ssh_key_path to its contents, or accepts ssh_key content
directly.

Renamed var & comments to clarify that it's a private key needed for metal installs.

Also removed unused public_key_path from metal-k8s.