### PR TITLE
feat(ps-cloud): managed ps-cloud install with ansible, published as a container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2.1
 
+orbs:
+  docker-tools: paperspace/docker-tools@0.0.4
+
+_docker_image_gradient_installer_ps_cloud: &docker_image_gradient_installer_ps_cloud paperspace/gradient-installer-ps-cloud
+_workspace_root: &workspace_root .
+
 jobs:
   terraform_plan:
     docker:
@@ -39,6 +45,19 @@ workflows:
           path: gradient-metal/tests
           workspace: default
           context: terraform
+          filters:
+            branches:
+              ignore: master
+
+      - docker-tools/build_and_push:
+          name: docker_build_and_push_ps_cloud
+          context: docker-deploy
+          docker_username: ${DOCKER_USERNAME}
+          docker_password: ${DOCKER_PASSWORD}
+          workspace_root: *workspace_root
+          docker_image: *docker_image_gradient_installer_ps_cloud
+          docker_tag: 0.0.0-latest
+          docker_file: Dockerfile-ps-cloud
           filters:
             branches:
               ignore: master

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
 roots
+**/.terraform
+**/*kubeconfig

--- a/Dockerfile-ps-cloud
+++ b/Dockerfile-ps-cloud
@@ -1,0 +1,13 @@
+FROM hashicorp/terraform:0.12.26
+
+RUN apk add ansible \
+    && apk add curl
+
+ADD ./bin/setup /home/paperspace/gradient-installer/bin/setup
+RUN /home/paperspace/gradient-installer/bin/setup
+
+WORKDIR /home/paperspace/gradient-installer
+
+ADD . ./
+
+ENTRYPOINT cd gradient-ps-cloud && sh bin/run

--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,7 @@ esac
 
 mkdir -p $TERRAFORM_PLUGINS_DIR
 
-curl -Ls https://github.com/Paperspace/terraform-provider-paperspace/releases/download/0.1.4/terraform-provider-paperspace-$TARGET -o $TERRAFORM_PLUGINS_DIR/terraform-provider-paperspace
+curl -Ls https://github.com/Paperspace/terraform-provider-paperspace/releases/download/0.1.7/terraform-provider-paperspace-$TARGET -o $TERRAFORM_PLUGINS_DIR/terraform-provider-paperspace
 chmod a+x $TERRAFORM_PLUGINS_DIR/terraform-provider-paperspace
 
 curl -Ls https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke_$TARGET -o $TERRAFORM_PLUGINS_DIR/terraform-provider-rke

--- a/gradient-ps-cloud/backends/managed.tf
+++ b/gradient-ps-cloud/backends/managed.tf
@@ -1,7 +1,0 @@
-terraform {
-    backend "s3" {
-        bucket = "gradient-managed-ps-cloud"
-        key    = "gradient-processing-ps-cloud-managed"
-        region = "us-east-1"
-    }
-}

--- a/gradient-ps-cloud/backends/managed.tf
+++ b/gradient-ps-cloud/backends/managed.tf
@@ -1,0 +1,7 @@
+terraform {
+    backend "s3" {
+        bucket = "gradient-managed-ps-cloud"
+        key    = "gradient-processing-ps-cloud-managed"
+        region = "us-east-1"
+    }
+}

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -18,5 +18,4 @@ terraform init
 # terraform apply reads terraform vars from env that are prefixed TF_VARS_
 terraform workspace new $TF_VAR_cluster_handle || true
 terraform workspace select $TF_VAR_cluster_handle
-export TF_LOG=debug
 terraform apply -auto-approve

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -18,4 +18,5 @@ terraform init
 # terraform apply reads terraform vars from env that are prefixed TF_VARS_
 terraform workspace new $TF_VAR_cluster_handle || true
 terraform workspace select $TF_VAR_cluster_handle
+export TF_LOG=debug
 terraform apply -auto-approve

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -2,8 +2,18 @@
 
 if [ $IS_MANAGED == "true" ] ; then
   echo "Configuring managed backend..."
-  cp backends/managed.tf ./
+
+  cat << EOF > ./backend.tf
+terraform {
+    backend "s3" {
+        bucket = "${AWS_BUCKET}"
+        key    = "gradient-processing-ps-cloud-managed"
+        region = "${AWS_DEFAULT_REGION}"
+    }
+}
+EOF
 fi
+
 terraform init
 # terraform apply reads terraform vars from env that are prefixed TF_VARS_
 terraform workspace new $TF_VAR_cluster_handle || true

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+if [ $IS_MANAGED == "true" ] ; then
+  echo "Configuring managed backend..."
+  cp backends/managed.tf ./
+fi
+terraform init
+# terraform apply reads terraform vars from env that are prefixed TF_VARS_
+terraform workspace new $TF_VAR_cluster_handle || true
+terraform workspace select $TF_VAR_cluster_handle
+terraform apply -auto-approve

--- a/gradient-ps-cloud/input.tf
+++ b/gradient-ps-cloud/input.tf
@@ -20,8 +20,8 @@ variable "aws_secret_access_key" {
     default = ""
 }
 
-variable "cloudflare_api_token" {
-    description = "Cloudflare API token"
+variable "cloudflare_api_key" {
+    description = "Cloudflare API key"
     default = ""
 }
 variable "cloudflare_email" {

--- a/gradient-ps-cloud/input.tf
+++ b/gradient-ps-cloud/input.tf
@@ -37,6 +37,12 @@ variable "cluster_id_integer" {
     description = "Cluster id integer"
 }
 
+variable "is_proxied" {
+    type = bool
+    description = "Is PS Cloud cluster managed by Paperspace"
+    default = false
+}
+
 variable "machine_storage_main" {
     type = number
     description = "Main storage id"

--- a/gradient-ps-cloud/input.tf
+++ b/gradient-ps-cloud/input.tf
@@ -1,53 +1,77 @@
-variable "admin_email" {}
+variable "admin_email" {
+    description = "Paperspace admin API email"
+}
 
-variable "admin_user_api_key" {}
+variable "admin_user_api_key" {
+    description = "Paperspace admin API key"
+}
 
 # variable "cluster_id" {}
 
 variable "machine_storage_main" {
-    default = 50
+    description = "Main storage id"
+    default = 100
 }
 variable "machine_template_id_main" {
+    description = "Main template id"
     default = "t04azgph"
 }
 variable "machine_type_main" {
+    description = "Main machine type"
     default = "C5"
 }
 
 variable "machine_count_worker_cpu" {
+    description = "Number of CPU workers"
     default = 3
 }
 variable "machine_storage_worker_cpu" {
-    default = 50
+    description = "CPU worker storage"
+    default = 100
 }
 variable "machine_template_id_cpu" {
+    description = "CPU template id"
     default = "t04azgph"
 }
 variable "machine_type_worker_cpu" {
+    description = "CPU worker machine type"
     default = "C5"
 }
 
 variable "machine_count_worker_gpu" {
+    description = "Number of GPU workers"
     default = 3
 }
 variable "machine_storage_worker_gpu" {
-    default = 50
+    description = "GPU worker storage"
+    default = 100
 }
 variable "machine_template_id_gpu" {
+    description = "GPU template id"
     default = "tmun4o2g"
 }
 variable "machine_type_worker_gpu" {
+    description = "GPU worker machine type"
     default = "P4000"
 }
 
-variable "network_id" {}
+variable "network_id" {
+    description = "Paperspace private network id"
+}
 
 variable "region" {
+    description = "Cloud region"
     default = "East Coast (NY2)"
 }
 
-variable "ssh_key_private" {}
+variable "ssh_key_path" {
+    description = "Private SSH key path"
+}
 
-variable "ssh_key_public" {}
+variable "ssh_key_public_path" {
+    description = "Public SSH key path"
+}
 
-variable "team_id" {}
+variable "team_id" {
+    description = "Cluster team id"
+}

--- a/gradient-ps-cloud/input.tf
+++ b/gradient-ps-cloud/input.tf
@@ -6,15 +6,45 @@ variable "admin_user_api_key" {
     description = "Paperspace admin API key"
 }
 
-# variable "cluster_id" {}
+variable "api_host" {
+    description = "api host"
+    default = "api.paperspace.io"
+}
+
+variable "aws_access_key_id" {
+    description = "AWS access key id"
+    default = ""
+}
+variable "aws_secret_access_key" {
+    description = "AWS secret access key"
+    default = ""
+}
+
+variable "cloudflare_api_token" {
+    description = "Cloudflare API token"
+    default = ""
+}
+variable "cloudflare_email" {
+    description = "Cloudflare email"
+    default = ""
+}
+variable "cloudflare_zone_id" {
+    description = "Cloudflare zone id"
+    default = ""
+}
+
+variable "cluster_id_integer" {
+    description = "Cluster id integer"
+}
 
 variable "machine_storage_main" {
+    type = number
     description = "Main storage id"
     default = 100
 }
 variable "machine_template_id_main" {
     description = "Main template id"
-    default = "t04azgph"
+    default = "tmun4o2g" # tmun4o2g is pre-installed with nvidia and docker; docker is needed for cpu, whereas nvidia is needed for gpu, but using this template introduces very little bloat and speeds up node configuration
 }
 variable "machine_type_main" {
     description = "Main machine type"
@@ -22,16 +52,18 @@ variable "machine_type_main" {
 }
 
 variable "machine_count_worker_cpu" {
+    type = number
     description = "Number of CPU workers"
     default = 3
 }
 variable "machine_storage_worker_cpu" {
+    type = number
     description = "CPU worker storage"
     default = 100
 }
 variable "machine_template_id_cpu" {
     description = "CPU template id"
-    default = "t04azgph"
+    default = "tmun4o2g" # tmun4o2g is pre-installed with nvidia and docker; docker is needed for cpu, whereas nvidia is needed for gpu, but using this template introduces very little bloat and speeds up node configuration
 }
 variable "machine_type_worker_cpu" {
     description = "CPU worker machine type"
@@ -39,10 +71,12 @@ variable "machine_type_worker_cpu" {
 }
 
 variable "machine_count_worker_gpu" {
+    type = number
     description = "Number of GPU workers"
     default = 3
 }
 variable "machine_storage_worker_gpu" {
+    type = number
     description = "GPU worker storage"
     default = 100
 }
@@ -55,23 +89,15 @@ variable "machine_type_worker_gpu" {
     default = "P4000"
 }
 
-variable "network_id" {
-    description = "Paperspace private network id"
-}
-
 variable "region" {
     description = "Cloud region"
     default = "East Coast (NY2)"
 }
 
-variable "ssh_key_path" {
-    description = "Private SSH key path"
-}
-
-variable "ssh_key_public_path" {
-    description = "Public SSH key path"
-}
-
 variable "team_id" {
     description = "Cluster team id"
+}
+
+variable "team_id_integer" {
+    description = "Cluster team id integer"
 }

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -17,7 +17,7 @@ data "paperspace_user" "admin" {
 }
 
 data "local_file" "ssh_key_content" {
-    filename = expandpath(local.ssh_key_path)
+    filename = pathexpand(local.ssh_key_path)
 }
 
 resource "null_resource" "write_public_ssh_key_file_for_ansible" {

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -62,7 +62,7 @@ resource "paperspace_machine" "gradient_main" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path))
+            private_key = tls_private_key.ssh_key.public_key_openssh
         }
     }
 
@@ -110,7 +110,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path))
+            private_key = tls_private_key.ssh_key.public_key_openssh
         }
     }
 
@@ -156,7 +156,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path))
+            private_key = tls_private_key.ssh_key.public_key_openssh
         }
     }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -62,7 +62,7 @@ resource "paperspace_machine" "gradient_main" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path)
+            private_key = file(pathexpand(local.ssh_key_path))
         }
     }
 
@@ -110,7 +110,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path)
+            private_key = file(pathexpand(local.ssh_key_path))
         }
     }
 
@@ -156,7 +156,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path)
+            private_key = file(pathexpand(local.ssh_key_path))
         }
     }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -19,8 +19,7 @@ data "paperspace_user" "admin" {
 resource "null_resource" "write_public_ssh_key_file_for_ansible" {
     provisioner "local-exec" {
         command = <<EOF
-            echo "${tls_private_key.ssh_key.private_key_pem}" >> ${local.ssh_key_path}
-            chmod 600 ${local.ssh_key_path}
+            echo "${tls_private_key.ssh_key.private_key_pem}" >> ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path}
         EOF
     }
 }
@@ -77,6 +76,7 @@ resource "paperspace_machine" "gradient_main" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${paperspace_machine.gradient_main.public_ip_address},' \
@@ -119,6 +119,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${self.public_ip_address},' \
@@ -159,6 +160,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${self.public_ip_address},' \

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -16,14 +16,6 @@ data "paperspace_user" "admin" {
     team_id = var.team_id
 }
 
-resource "null_resource" "write_public_ssh_key_file_for_ansible" {
-    provisioner "local-exec" {
-        command = <<EOF
-            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path}
-        EOF
-    }
-}
-
 resource "paperspace_script" "add_public_ssh_key" {
     name = "Add public SSH key"
     description = "Add public SSH key on machine create"
@@ -49,7 +41,6 @@ resource "paperspace_machine" "gradient_main" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     region = var.region
@@ -76,6 +67,7 @@ resource "paperspace_machine" "gradient_main" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${paperspace_machine.gradient_main.public_ip_address},' \
@@ -90,7 +82,6 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_cpu
@@ -118,6 +109,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${self.public_ip_address},' \
@@ -130,7 +122,6 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_gpu
@@ -158,6 +149,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${self.public_ip_address},' \

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -42,6 +42,25 @@ resource "paperspace_machine" "gradient_main" {
     network_id = paperspace_network.main.id
     # cluster_id = var.cluster_id // coming soon
 
+    connection {
+        type     = "ssh"
+        user     = "paperspace"
+        host     = self.public_ip_address
+        private_key = var.ssh_key_path
+    }
+
+    provisioner "ssh-exec" {
+        command = <<EOF
+            ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
+            --key-file ${var.ssh_key_path} \
+            -i '${paperspace_machine.gradient_main.public_ip_address},' \
+            -e "install_nfs_server=true" \
+            -e "nfs_subnet_host_with_netmask=${data.paperspace_network.network.network}/${data.paperspace_network.network.netmask}" \
+            ${path.module}/ansible/playbook-gradient-metal-ps-cloud-node.yaml
+        EOF
+    }
+
+
     provisioner "local-exec" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
@@ -69,6 +88,13 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     network_id = paperspace_network.main.id
     # cluster_id = var.cluster_id
 
+    connection {
+        type     = "ssh"
+        user     = "paperspace"
+        host     = self.public_ip_address
+        private_key = var.ssh_key_path
+    }
+
     provisioner "local-exec" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
@@ -93,6 +119,13 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.main.id
     # cluster_id = var.cluster_id
+
+    connection {
+        type     = "ssh"
+        user     = "paperspace"
+        host     = self.public_ip_address
+        private_key = var.ssh_key_path
+    }
 
     provisioner "local-exec" {
         command = <<EOF

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -66,6 +66,15 @@ resource "paperspace_machine" "gradient_main" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
+    provisioner "remote-exec" {
+        connection {
+            type     = "ssh"
+            user     = "paperspace"
+            host     = self.public_ip_address
+            private_key = tls_private_key.ssh_key.private_key_pem
+        }
+    } 
+
     provisioner "local-exec" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
@@ -99,6 +108,15 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
+    provisioner "remote-exec" {
+        connection {
+            type     = "ssh"
+            user     = "paperspace"
+            host     = self.public_ip_address
+            private_key = tls_private_key.ssh_key.private_key_pem
+        }
+    } 
+
     provisioner "local-exec" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
@@ -129,6 +147,15 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.network.handle
     live_forever = true
+
+    provisioner "remote-exec" {
+        connection {
+            type     = "ssh"
+            user     = "paperspace"
+            host     = self.public_ip_address
+            private_key = tls_private_key.ssh_key.private_key_pem
+        }
+    } 
 
     provisioner "local-exec" {
         command = <<EOF

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -250,6 +250,32 @@ resource "null_resource" "add_machine_to_cluster_worker_gpu" {
     }
 }
 
+provider "cloudflare" {
+    version = "~> 2.0"
+    email   = var.cloudflare_email
+    api_token = var.cloudflare_api_token
+}
+
+resource "cloudflare_record" "subdomain" {
+    count = var.cloudflare_api_token == "" && var.cloudflare_email == "" && var.cloudflare_zone_id == "" ? 0 : 1
+    zone_id = var.cloudflare_zone_id
+    name    = var.domain
+    value   = paperspace_machine.gradient_main.public_ip_address
+    type    = "A"
+    ttl     = 3600
+    proxied = var.is_proxied
+}
+
+resource "cloudflare_record" "subdomain_wildcard" {
+    count = var.cloudflare_api_token == "" && var.cloudflare_email == "" && var.cloudflare_zone_id == "" ? 0 : 1
+    zone_id = var.cloudflare_zone_id
+    name    = "*.${var.domain}"
+    value   = paperspace_machine.gradient_main.public_ip_address
+    type    = "A"
+    ttl     = 3600
+    proxied = var.is_proxied
+}
+
 output "main_node_public_ip_address" {
   value = paperspace_machine.gradient_main.public_ip_address
 }

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -65,7 +65,7 @@ resource "paperspace_machine" "gradient_main" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = var.ssh_key_path
+            private_key = local.ssh_key_path
         }
     }
 
@@ -107,7 +107,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = var.ssh_key_path
+            private_key = local.ssh_key_path
         }
     }
 
@@ -147,7 +147,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = var.ssh_key_path
+            private_key = local.ssh_key_path
         }
     }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -42,7 +42,7 @@ resource "paperspace_machine" "gradient_main" {
             -i '${paperspace_machine.gradient_main.public_ip_address},' \
             -e "install_nfs_server=true" \
             -e "nfs_subnet_host_with_netmask=${data.paperspace_network.network.network}/${data.paperspace_network.network.netmask}" \
-            ansible/playbook-gradient-metal-ps-cloud-node.yaml
+            ${path.module}/ansible/playbook-gradient-metal-ps-cloud-node.yaml
         EOF
     }
 }
@@ -65,7 +65,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             -i '${self.public_ip_address},' \
-            ansible/playbook-gradient-metal-ps-cloud-node.yaml
+            ${path.module}/ansible/playbook-gradient-metal-ps-cloud-node.yaml
         EOF
     }
 }
@@ -88,7 +88,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             -i '${self.public_ip_address},' \
-            ansible/playbook-gradient-metal-ps-cloud-node.yaml
+            ${path.module}/ansible/playbook-gradient-metal-ps-cloud-node.yaml
         EOF
     }
 }

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -60,24 +60,14 @@ resource "paperspace_machine" "gradient_main" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    connection {
-        type     = "ssh"
-        user     = "paperspace"
-        host     = self.public_ip_address
-        private_key = var.ssh_key_path
+    provisioner "remote-exec" {
+        connection {
+            type     = "ssh"
+            user     = "paperspace"
+            host     = self.public_ip_address
+            private_key = var.ssh_key_path
+        }
     }
-
-    provisioner "ssh-exec" {
-        command = <<EOF
-            ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
-            --key-file ${var.ssh_key_path} \
-            -i '${paperspace_machine.gradient_main.public_ip_address},' \
-            -e "install_nfs_server=true" \
-            -e "nfs_subnet_host_with_netmask=${data.paperspace_network.network.network}/${data.paperspace_network.network.netmask}" \
-            ${path.module}/ansible/playbook-gradient-metal-ps-cloud-node.yaml
-        EOF
-    }
-
 
     provisioner "local-exec" {
         command = <<EOF
@@ -112,11 +102,13 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    connection {
-        type     = "ssh"
-        user     = "paperspace"
-        host     = self.public_ip_address
-        private_key = var.ssh_key_path
+    provisioner "remote-exec" {
+        connection {
+            type     = "ssh"
+            user     = "paperspace"
+            host     = self.public_ip_address
+            private_key = var.ssh_key_path
+        }
     }
 
     provisioner "local-exec" {
@@ -150,11 +142,13 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    connection {
-        type     = "ssh"
-        user     = "paperspace"
-        host     = self.public_ip_address
-        private_key = var.ssh_key_path
+    provisioner "remote-exec" {
+        connection {
+            type     = "ssh"
+            user     = "paperspace"
+            host     = self.public_ip_address
+            private_key = var.ssh_key_path
+        }
     }
 
     provisioner "local-exec" {

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -53,7 +53,7 @@ resource "paperspace_machine" "gradient_main" {
     provisioner "local-exec" {
         command = <<EOF
             echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
-            chmod 600
+            chmod 600 ${local.ssh_key_path}
         EOF
     }
 
@@ -101,7 +101,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     provisioner "local-exec" {
         command = <<EOF
             echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
-            chmod 600
+            chmod 600 ${local.ssh_key_path}
         EOF
     }
 
@@ -147,7 +147,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     provisioner "local-exec" {
         command = <<EOF
             echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
-            chmod 600
+            chmod 600 ${local.ssh_key_path}
         EOF
     }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -246,6 +246,9 @@ resource "null_resource" "complete_cluster_create" {
     }
 }
 
+
+// Disable because of metal for now
+/*
 resource "null_resource" "add_machine_to_cluster_main" {
     depends_on = [module.gradient_metal]
 
@@ -279,6 +282,7 @@ resource "null_resource" "add_machine_to_cluster_worker_gpu" {
         EOF
     }
 }
+*/
 
 provider "cloudflare" {
     version = "~> 2.0"

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -81,7 +81,7 @@ resource "paperspace_machine" "gradient_main" {
     }
 }
 
-resorce "paperspace_machine" "gradient_workers_cpu" {
+resource "paperspace_machine" "gradient_workers_cpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -62,7 +62,7 @@ resource "paperspace_machine" "gradient_main" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = data.local_file.ssh_key_content.content
+            private_key = file(pathexpand(local.ssh_key_path)
         }
     }
 
@@ -110,7 +110,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = data.local_file.ssh_key_content.content
+            private_key = file(pathexpand(local.ssh_key_path)
         }
     }
 
@@ -156,7 +156,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = data.local_file.ssh_key_content.content
+            private_key = file(pathexpand(local.ssh_key_path)
         }
     }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -60,15 +60,6 @@ resource "paperspace_machine" "gradient_main" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    provisioner "remote-exec" {
-        connection {
-            type     = "ssh"
-            user     = "paperspace"
-            host     = self.public_ip_address
-            private_key = tls_private_key.ssh_key.private_key_pem
-        }
-    }
-
     provisioner "local-exec" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
@@ -102,15 +93,6 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    provisioner "remote-exec" {
-        connection {
-            type     = "ssh"
-            user     = "paperspace"
-            host     = self.public_ip_address
-            private_key = tls_private_key.ssh_key.private_key_pem
-        }
-    }
-
     provisioner "local-exec" {
         command = <<EOF
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
@@ -141,15 +123,6 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.network.handle
     live_forever = true
-
-    provisioner "remote-exec" {
-        connection {
-            type     = "ssh"
-            user     = "paperspace"
-            host     = self.public_ip_address
-            private_key = tls_private_key.ssh_key.public_key_openssh
-        }
-    }
 
     provisioner "local-exec" {
         command = <<EOF

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -19,7 +19,7 @@ data "paperspace_user" "admin" {
 resource "null_resource" "write_public_ssh_key_file_for_ansible" {
     provisioner "local-exec" {
         command = <<EOF
-            echo "${tls_private_key.ssh_key.private_key_pem}" >> ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path}
+            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path}
         EOF
     }
 }
@@ -76,8 +76,6 @@ resource "paperspace_machine" "gradient_main" {
 
     provisioner "local-exec" {
         command = <<EOF
-            echo "PUBLIC_KEY: ${tls_private_key.ssh_key.public_key_openssh}" && \
-            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${paperspace_machine.gradient_main.public_ip_address},' \
@@ -120,8 +118,6 @@ resource "paperspace_machine" "gradient_workers_cpu" {
 
     provisioner "local-exec" {
         command = <<EOF
-            echo "PUBLIC_KEY: ${tls_private_key.ssh_key.public_key_openssh}" && \
-            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${self.public_ip_address},' \
@@ -162,8 +158,6 @@ resource "paperspace_machine" "gradient_workers_gpu" {
 
     provisioner "local-exec" {
         command = <<EOF
-            echo "PUBLIC_KEY: ${tls_private_key.ssh_key.public_key_openssh}" && \
-            echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
             -i '${self.public_ip_address},' \

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -209,8 +209,6 @@ resource "null_resource" "complete_cluster_create" {
 
     provisioner "local-exec" {
         command = <<EOF
-            curl -H 'Content-Type:application/json' -H 'X-API-Key: ${var.cluster_apikey}' -XPUT '${var.api_host}/clusters/secrets/${var.cluster_handle}_ssh_key_base64' -d '{"clusterId":"${var.cluster_handle}", "value":"${base64encode(tls_private_key.ssh_key.private_key_pem)}"}'
-            curl -H 'Content-Type:application/json' -H 'X-API-Key: ${var.cluster_apikey}' -XPUT '${var.api_host}/clusters/secrets/${var.cluster_handle}_kubeconfig' -d '{"clusterId":"${var.cluster_handle}","value":"${base64encode(file(pathexpand(var.kubeconfig_path)))}"}'
             curl -H 'Content-Type:application/json' -H 'X-API-Key: ${var.cluster_apikey}' -XPOST '${var.api_host}/clusters/updateCluster' -d '{"id":"${var.cluster_handle}", "attributes":{"networkId":"${paperspace_network.network.id}"}}'
         EOF
     }

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -16,6 +16,10 @@ data "paperspace_user" "admin" {
     team_id = var.team_id
 }
 
+data "local_file" "ssh_key_content" {
+    filename = expandpath(local.ssh_key_path)
+}
+
 resource "null_resource" "write_public_ssh_key_file_for_ansible" {
     provisioner "local-exec" {
         command = <<EOF
@@ -65,7 +69,7 @@ resource "paperspace_machine" "gradient_main" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path))
+            private_key = data.local_file.ssh_key_content.content
         }
     }
 
@@ -107,7 +111,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path))
+            private_key = data.local_file.ssh_key_content.content
         }
     }
 
@@ -147,7 +151,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = file(pathexpand(local.ssh_key_path))
+            private_key = data.local_file.ssh_key_content.content
         }
     }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -251,11 +251,11 @@ resource "null_resource" "add_machine_to_cluster_worker_gpu" {
 provider "cloudflare" {
     version = "~> 2.0"
     email   = var.cloudflare_email
-    api_token = var.cloudflare_api_token
+    api_key = var.cloudflare_api_key
 }
 
 resource "cloudflare_record" "subdomain" {
-    count = var.cloudflare_api_token == "" && var.cloudflare_email == "" && var.cloudflare_zone_id == "" ? 0 : 1
+    count = var.cloudflare_api_key == "" && var.cloudflare_email == "" && var.cloudflare_zone_id == "" ? 0 : 1
     zone_id = var.cloudflare_zone_id
     name    = var.domain
     value   = paperspace_machine.gradient_main.public_ip_address
@@ -265,7 +265,7 @@ resource "cloudflare_record" "subdomain" {
 }
 
 resource "cloudflare_record" "subdomain_wildcard" {
-    count = var.cloudflare_api_token == "" && var.cloudflare_email == "" && var.cloudflare_zone_id == "" ? 0 : 1
+    count = var.cloudflare_api_key == "" && var.cloudflare_email == "" && var.cloudflare_zone_id == "" ? 0 : 1
     zone_id = var.cloudflare_zone_id
     name    = "*.${var.domain}"
     value   = paperspace_machine.gradient_main.public_ip_address

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -16,6 +16,15 @@ data "paperspace_user" "admin" {
     team_id = var.team_id
 }
 
+resource "null_resource" "write_public_ssh_key_file_for_ansible" {
+    provisioner "local-exec" {
+        command = <<EOF
+            echo "${tls_private_key.ssh_key.private_key_pem}" >> ${local.ssh_key_path}
+            chmod 600 ${local.ssh_key_path}
+        EOF
+    }
+}
+
 resource "paperspace_script" "add_public_ssh_key" {
     name = "Add public SSH key"
     description = "Add public SSH key on machine create"
@@ -35,6 +44,7 @@ resource "paperspace_machine" "gradient_main" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
+        null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     region = var.region
@@ -50,19 +60,12 @@ resource "paperspace_machine" "gradient_main" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    provisioner "local-exec" {
-        command = <<EOF
-            echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
-            chmod 600 ${local.ssh_key_path}
-        EOF
-    }
-
     provisioner "remote-exec" {
         connection {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = tls_private_key.ssh_key.public_key_openssh
+            private_key = tls_private_key.ssh_key.private_key_pem
         }
     }
 
@@ -78,10 +81,11 @@ resource "paperspace_machine" "gradient_main" {
     }
 }
 
-resource "paperspace_machine" "gradient_workers_cpu" {
+resorce "paperspace_machine" "gradient_workers_cpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
+        null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_cpu
@@ -98,19 +102,12 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     network_id = paperspace_network.network.handle
     live_forever = true
 
-    provisioner "local-exec" {
-        command = <<EOF
-            echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
-            chmod 600 ${local.ssh_key_path}
-        EOF
-    }
-
     provisioner "remote-exec" {
         connection {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = tls_private_key.ssh_key.public_key_openssh
+            private_key = tls_private_key.ssh_key.private_key_pem
         }
     }
 
@@ -128,6 +125,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
+        null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_gpu
@@ -143,13 +141,6 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.network.handle
     live_forever = true
-
-    provisioner "local-exec" {
-        command = <<EOF
-            echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
-            chmod 600 ${local.ssh_key_path}
-        EOF
-    }
 
     provisioner "remote-exec" {
         connection {

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -50,7 +50,8 @@ resource "paperspace_machine" "gradient_main" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        null_resource.write_public_ssh_key_file_for_ansible,
+        data.local_file.ssh_key_content,
+        #null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     region = var.region
@@ -91,7 +92,8 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        null_resource.write_public_ssh_key_file_for_ansible,
+        data.local_file.ssh_key_content,
+        #null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_cpu
@@ -131,7 +133,8 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        null_resource.write_public_ssh_key_file_for_ansible,
+        data.local_file.ssh_key_content,
+        #null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_gpu

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -16,21 +16,6 @@ data "paperspace_user" "admin" {
     team_id = var.team_id
 }
 
-data "local_file" "ssh_key_content" {
-    depends_on = [null_resource.write_public_ssh_key_file_for_ansible]
-
-    filename = pathexpand(local.ssh_key_path)
-}
-
-resource "null_resource" "write_public_ssh_key_file_for_ansible" {
-    provisioner "local-exec" {
-        command = <<EOF
-            echo "${tls_private_key.ssh_key.private_key_pem}" >> ${local.ssh_key_path}
-            chmod 600 ${local.ssh_key_path}
-        EOF
-    }
-}
-
 resource "paperspace_script" "add_public_ssh_key" {
     name = "Add public SSH key"
     description = "Add public SSH key on machine create"
@@ -50,8 +35,6 @@ resource "paperspace_machine" "gradient_main" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        data.local_file.ssh_key_content,
-        #null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     region = var.region
@@ -66,6 +49,13 @@ resource "paperspace_machine" "gradient_main" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.network.handle
     live_forever = true
+
+    provisioner "local-exec" {
+        command = <<EOF
+            echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
+            chmod 600
+        EOF
+    }
 
     provisioner "remote-exec" {
         connection {
@@ -92,8 +82,6 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        data.local_file.ssh_key_content,
-        #null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_cpu
@@ -109,6 +97,13 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.network.handle
     live_forever = true
+
+    provisioner "local-exec" {
+        command = <<EOF
+            echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
+            chmod 600
+        EOF
+    }
 
     provisioner "remote-exec" {
         connection {
@@ -133,8 +128,6 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
-        data.local_file.ssh_key_content,
-        #null_resource.write_public_ssh_key_file_for_ansible,
     ]
 
     count = var.machine_count_worker_gpu
@@ -150,6 +143,13 @@ resource "paperspace_machine" "gradient_workers_gpu" {
     script_id = paperspace_script.add_public_ssh_key.id
     network_id = paperspace_network.network.handle
     live_forever = true
+
+    provisioner "local-exec" {
+        command = <<EOF
+            echo "${tls_private_key.ssh_key.public_key_openssh}" >> ${local.ssh_key_path}
+            chmod 600
+        EOF
+    }
 
     provisioner "remote-exec" {
         connection {

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -34,6 +34,12 @@ resource "paperspace_script" "add_public_ssh_key" {
     EOF
     is_enabled = true
     run_once = true
+
+    provisioner "local-exec" {
+        command = <<EOF
+            sleep 20
+        EOF
+    }
 }
 
 resource "paperspace_network" "network" {

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -76,6 +76,7 @@ resource "paperspace_machine" "gradient_main" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "PUBLIC_KEY: ${tls_private_key.ssh_key.public_key_openssh}" && \
             echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
@@ -119,6 +120,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "PUBLIC_KEY: ${tls_private_key.ssh_key.public_key_openssh}" && \
             echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \
@@ -160,6 +162,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
 
     provisioner "local-exec" {
         command = <<EOF
+            echo "PUBLIC_KEY: ${tls_private_key.ssh_key.public_key_openssh}" && \
             echo "${tls_private_key.ssh_key.private_key_pem}" > ${local.ssh_key_path} && chmod 600 ${local.ssh_key_path} && \
             ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
             --key-file ${local.ssh_key_path} \

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -17,6 +17,8 @@ data "paperspace_user" "admin" {
 }
 
 data "local_file" "ssh_key_content" {
+    depends_on = [null_resource.write_public_ssh_key_file_for_ansible]
+
     filename = pathexpand(local.ssh_key_path)
 }
 

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -54,7 +54,7 @@ resource "paperspace_machine" "gradient_main" {
 
     region = var.region
     name = "${var.cluster_handle}-${var.name}-main"
-    machine_type = var.machine_type_main
+    machine_type = "P4000"
     size = var.machine_storage_main
     billing_type = "hourly"
     assign_public_ip = true
@@ -98,7 +98,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
     count = var.machine_count_worker_cpu
     region = var.region
     name = "${var.cluster_handle}-${var.name}-worker-cpu-${count.index}"
-    machine_type = var.machine_type_worker_cpu
+    machine_type = "P4000"
     size = var.machine_storage_worker_cpu
     billing_type = "hourly"
     assign_public_ip = true

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -65,7 +65,7 @@ resource "paperspace_machine" "gradient_main" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = local.ssh_key_path
+            private_key = file(pathexpand(local.ssh_key_path))
         }
     }
 
@@ -81,7 +81,7 @@ resource "paperspace_machine" "gradient_main" {
     }
 }
 
-resource "paperspace_machine" "gradient_workers_cpu" {
+resorce "paperspace_machine" "gradient_workers_cpu" {
     depends_on = [
         paperspace_script.add_public_ssh_key,
         tls_private_key.ssh_key,
@@ -107,7 +107,7 @@ resource "paperspace_machine" "gradient_workers_cpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = local.ssh_key_path
+            private_key = file(pathexpand(local.ssh_key_path))
         }
     }
 
@@ -147,7 +147,7 @@ resource "paperspace_machine" "gradient_workers_gpu" {
             type     = "ssh"
             user     = "paperspace"
             host     = self.public_ip_address
-            private_key = local.ssh_key_path
+            private_key = file(pathexpand(local.ssh_key_path))
         }
     }
 


### PR DESCRIPTION
This PR creates a new SSH key dynamically, ensures that ansible uses that, and then writes that private ssh-key back as a secret to the team's secrets.

This eliminates the need to pass in ssh keys.

It also writes the cluster's kubeconfig as a cluster secret and the cluster id back to the cluster.

It also adds terraform various `depends_on`s to make sure the DAG runs in a good order.

Co-authored-by: Philip Reichenberger <philip@paperspace.com>
Co-authored-by: Jared Scheib <jared.scheib@gmail.com>