### PR TITLE
ci(ps-cloud): only build & push installer image from main ('master') branch PS-14492

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,4 +60,4 @@ workflows:
           docker_file: Dockerfile-ps-cloud
           filters:
             branches:
-              ignore: master
+              only: master


### PR DESCRIPTION
Now that the main branch (`master`) is functional and relatively stable, we don't want to re-build the image at every branch push. cc @reynld to be aware on the API side, since we're consuming the latest image there.