### PR TITLE
feat(ps-cloud): ability to delete managed terraform cluster by env var PS-14546

### DIFF
--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -23,7 +23,6 @@ terraform workspace select $TF_VAR_cluster_handle
 
 if [ $TERRAFORM_COMMAND == "destroy" ] ; then
   terraform destroy -auto-approve
-  exit 0
+else
+  terraform apply -auto-approve
 fi
-
-terraform apply -auto-approve

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -22,8 +22,8 @@ terraform workspace new $TF_VAR_cluster_handle || true
 terraform workspace select $TF_VAR_cluster_handle
 
 if [ $TERRAFORM_COMMAND == "destroy" ] ; then
-  terraform destroy
+  terraform destroy -auto-approve
   exit 0
 fi
 
-terraform apply
+terraform apply -auto-approve

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
 
+# Note: Terraform reads vars from env vars that are prefixed TF_VARS_,
+# and they'll be named whatever the rest of the env var name is.
+
 if [ $TF_VAR_is_managed == "true" ] ; then
   echo "Configuring managed backend..."
 
@@ -15,7 +18,12 @@ EOF
 fi
 
 terraform init
-# terraform apply reads terraform vars from env that are prefixed TF_VARS_
 terraform workspace new $TF_VAR_cluster_handle || true
 terraform workspace select $TF_VAR_cluster_handle
-terraform apply -auto-approve
+
+if [ $TERRAFORM_COMMAND == "destroy" ] ; then
+  terraform destroy
+  exit 0
+fi
+
+terraform apply


### PR DESCRIPTION
By default, running the terraform argo job will run `terraform apply`.  However, if you pass in `TERRAFORM_COMMAND=destroy`,  it will destroy the resources that terraform created: machines, dns records, etc.