### PR TITLE
feat: container registry credentials N-34

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,31 @@
 
 Run the [Gradient MLOps Platform](https://gradient.paperspace.com) anywhere. The Gradient Installer is a CLI to setup and manage [Gradient private clusters](https://docs.paperspace.com/gradient/gradient-private-cloud/setup) on AWS, NVIDIA DGX-1, and any VM / Bare metal.
 
-
 Terraform is used under the hood to setup all the infrastructure. Terraform modules can also be used directly to integrate Gradient into an existing Terraform setup.
 
 ### Supported target platforms
+
 - AWS EKS
 - NVIDIA DGX
 - VM / Bare metal
-- GCP (GKE) *(coming soon)*
-- Azure (AKS) *(coming soon)*
+- GCP (GKE) _(coming soon)_
+- Azure (AKS) _(coming soon)_
 
 ## Prerequisites
+
 - A Paperspace account with an appropriate billing plan and API key [https://www.paperspace.com]
 - An AWS S3 bucket to store Terraform state [https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html]
 
 ## Install / Update
+
 ### Install
+
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/paperspace/gradient-installer/master/bin/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Paperspace/gradient-installer/master/bin/install)"
 ```
 
 ### Updating
+
 ```sh
 gradient-installer update
 ```
@@ -35,34 +39,40 @@ gradient-installer update
 
 <img width="633" alt="clusterInstaller-help" src="https://user-images.githubusercontent.com/585865/89807443-a0115a80-db06-11ea-8226-c68c884b03ae.png">
 
-
 ### Setting up a Gradient private cluster
+
 ```sh
 gradient-installer clusters up
 ```
+
 <img width="633" alt="GradientInstallerCLI-up" src="https://user-images.githubusercontent.com/585865/88327177-cb1d4100-ccf4-11ea-8ea8-2c4966c5dd88.png">
 
-
 ### Updating existing clusters
+
 ```sh
 gradient-installer clusters up CLUSTER_HANDLE
 ```
 
 ### Profiles
+
 The CLI supports multiple profiles, which can be used for different teams. You can use a profile by:
+
 ```sh
 export PAPERSPACE_PROFILE=favorite-team
 gradient-installer setup
 ```
 
 ## Terraform
+
 To keep track of your cluster' state, the CLI stores your state file in an S3 bucket.
-Terraform modules can be used directly to create clusters. 
+Terraform modules can be used directly to create clusters.
 
 List of available Terraform modules:
+
 - gradient-aws
 - gradient-metal
 - gradient-ps-cloud
 
 ## Documentation
+
 Full docs: https://docs.paperspace.com/gradient/gradient-private-cloud/about

--- a/cmd/gradient-installer/main.go
+++ b/cmd/gradient-installer/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/paperspace/gradient-installer/pkg/cli"
-	"github.com/paperspace/gradient-installer/pkg/cli/commands"
-	"github.com/paperspace/gradient-installer/pkg/cli/config"
+	"github.com/Paperspace/gradient-installer/pkg/cli"
+	"github.com/Paperspace/gradient-installer/pkg/cli/commands"
+	"github.com/Paperspace/gradient-installer/pkg/cli/config"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/Paperspace/paperspace-go v0.3.3
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.9.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/manifoldco/promptui v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
-module github.com/paperspace/gradient-installer
+module github.com/Paperspace/gradient-installer
 
 go 1.14
 
 require (
+	github.com/Paperspace/paperspace-go v0.3.3
 	github.com/fatih/color v1.9.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/manifoldco/promptui v0.7.0
-	github.com/paperspace/paperspace-go v0.0.4
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Paperspace/paperspace-go v0.3.3 h1:lkTpzJtl3ZpPtLCv0JhmY/T7j4n5H2FsEB+bSKzl29g=
+github.com/Paperspace/paperspace-go v0.3.3/go.mod h1:dtV/8NzfKc0mPp8zw6Gu2mUvWL5wvOYp/BV+0oaqoc0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -89,8 +91,6 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/paperspace/paperspace-go v0.0.4 h1:WdzGP7bisasC9r6GVP8MDkGdm5vFCpnpgu+I151EYCc=
-github.com/paperspace/paperspace-go v0.0.4/go.mod h1:IsIrciX+xQ+kBeQG3JJfVLKxct6UKy3QrJ34+HVNbGE=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/cli/commands/clusters.go
+++ b/pkg/cli/commands/clusters.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"github.com/paperspace/gradient-installer/pkg/cli/commands/clusters"
+	"github.com/Paperspace/gradient-installer/pkg/cli/commands/clusters"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/commands/clusters/down.go
+++ b/pkg/cli/commands/clusters/down.go
@@ -3,9 +3,9 @@ package clusters
 import (
 	"path/filepath"
 
-	"github.com/paperspace/gradient-installer/pkg/cli"
-	"github.com/paperspace/gradient-installer/pkg/cli/config"
-	"github.com/paperspace/gradient-installer/pkg/cli/terraform"
+	"github.com/Paperspace/gradient-installer/pkg/cli"
+	"github.com/Paperspace/gradient-installer/pkg/cli/config"
+	"github.com/Paperspace/gradient-installer/pkg/cli/terraform"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/commands/clusters/list.go
+++ b/pkg/cli/commands/clusters/list.go
@@ -1,8 +1,8 @@
 package clusters
 
 import (
-	"github.com/paperspace/gradient-installer/pkg/cli"
-	"github.com/paperspace/paperspace-go"
+	"github.com/Paperspace/gradient-installer/pkg/cli"
+	"github.com/Paperspace/paperspace-go"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/commands/clusters/register.go
+++ b/pkg/cli/commands/clusters/register.go
@@ -23,7 +23,6 @@ func ClusterRegister(client *paperspace.Client, createFilePath string) (string, 
 	var params paperspace.ClusterCreateParams
 	var region string
 
-	client.CreateCluster(paperspace.ClusterCreateParams{})
 	if createFilePath == "" {
 		awsRegionSelect := promptui.Select{
 			Label: "AWS Region",

--- a/pkg/cli/commands/clusters/register.go
+++ b/pkg/cli/commands/clusters/register.go
@@ -15,6 +15,7 @@ import (
 const (
 	InClusterContainerRegistryOption  = "Install on cluster"
 	ThirdPartyContainerRegistryOption = "Use 3rd Party"
+	NoContainerRegistry               = "No container registry"
 )
 
 func ClusterRegister(client *paperspace.Client, createFilePath string) (string, error) {
@@ -54,9 +55,8 @@ func ClusterRegister(client *paperspace.Client, createFilePath string) (string, 
 			Items: terraform.SupportedClusterPlatformTypes,
 		}
 		useContainerRegistrySelect := promptui.Select{
-			Label: "Container Registry",
-			// TODO(bbatha) enable in cluster registry PS-13895
-			Items: []string{ThirdPartyContainerRegistryOption /*, InClusterContainerRegistryOption*/},
+			Label: "Container Registry, used for storing notebook snapshots and container builds",
+			Items: []string{ThirdPartyContainerRegistryOption, NoContainerRegistry},
 		}
 		containerRegistryURLPrompt := cli.Prompt{
 			Label:    "Container Registry Username",

--- a/pkg/cli/commands/clusters/register.go
+++ b/pkg/cli/commands/clusters/register.go
@@ -59,11 +59,11 @@ func ClusterRegister(client *paperspace.Client, createFilePath string) (string, 
 			Items: []string{ThirdPartyContainerRegistryOption, NoContainerRegistry},
 		}
 		containerRegistryURLPrompt := cli.Prompt{
-			Label:    "Container Registry Username",
+			Label:    "Container Registry URL",
 			Required: true,
 		}
 		containerRegistryRepositoryPrompt := cli.Prompt{
-			Label:    "Container Registry Username",
+			Label:    "Container Registry Repository",
 			Required: true,
 		}
 		containerRegistryUsernamePrompt := cli.Prompt{
@@ -71,7 +71,7 @@ func ClusterRegister(client *paperspace.Client, createFilePath string) (string, 
 			Required: true,
 		}
 		containerRegistryPasswordPrompt := cli.Prompt{
-			Label:    "Container Registry Username",
+			Label:    "Container Registry Password",
 			Required: true,
 			UseMask:  true,
 		}

--- a/pkg/cli/commands/clusters/register.go
+++ b/pkg/cli/commands/clusters/register.go
@@ -71,9 +71,9 @@ func ClusterRegister(client *paperspace.Client, createFilePath string) (string, 
 			Required: true,
 		}
 		containerRegistryPasswordPrompt := cli.Prompt{
-			Label:    "Container Registry Password",
-			Required: true,
-			UseMask:  true,
+			Label:     "Container Registry Password",
+			Required:  true,
+			UseMask:   true,
 		}
 
 		println(cli.TextHeader("Register a private cluster"))

--- a/pkg/cli/commands/clusters/up.go
+++ b/pkg/cli/commands/clusters/up.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Paperspace/gradient-installer/pkg/cli"
+	"github.com/Paperspace/gradient-installer/pkg/cli/config"
+	"github.com/Paperspace/gradient-installer/pkg/cli/terraform"
+	"github.com/Paperspace/paperspace-go"
 	"github.com/manifoldco/promptui"
-	"github.com/paperspace/gradient-installer/pkg/cli"
-	"github.com/paperspace/gradient-installer/pkg/cli/config"
-	"github.com/paperspace/gradient-installer/pkg/cli/terraform"
-	"github.com/paperspace/paperspace-go"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/commands/setup.go
+++ b/pkg/cli/commands/setup.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"github.com/paperspace/gradient-installer/pkg/cli"
-	"github.com/paperspace/gradient-installer/pkg/cli/config"
-	"github.com/paperspace/gradient-installer/pkg/cli/terraform"
+	"github.com/Paperspace/gradient-installer/pkg/cli"
+	"github.com/Paperspace/gradient-installer/pkg/cli/config"
+	"github.com/Paperspace/gradient-installer/pkg/cli/terraform"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/commands/update.go
+++ b/pkg/cli/commands/update.go
@@ -11,8 +11,8 @@ import (
 	"regexp"
 	"runtime"
 
+	"github.com/Paperspace/gradient-installer/pkg/cli"
 	"github.com/google/go-github/v32/github"
-	"github.com/paperspace/gradient-installer/pkg/cli"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/config/profile.go
+++ b/pkg/cli/config/profile.go
@@ -3,7 +3,7 @@ package config
 import (
 	"os"
 
-	"github.com/paperspace/paperspace-go"
+	"github.com/Paperspace/paperspace-go"
 )
 
 type Profile struct {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/paperspace/paperspace-go"
+	"github.com/Paperspace/paperspace-go"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/prompt.go
+++ b/pkg/cli/prompt.go
@@ -28,11 +28,7 @@ func BoolToYesNo(value bool) string {
 }
 
 func YesNoToBool(value string) bool {
-	if value == "yes" {
-		return true
-	}
-
-	return false
+	return value == "yes"
 }
 
 func (p *Prompt) MaskValue(value string) string {
@@ -71,12 +67,16 @@ func (p *Prompt) Run() error {
 	// to empty the input buffer at these lengths to have larger inputs
 	// for values like GCP keys. You need a library like readline to manipulate
 	// tty modes to read longer inputs
-	rl, err := readline.New(prompt)
-	if err != nil {
-		return err
-	}
 	for {
-		value, err := rl.Readline()
+		var value string
+		var err error
+		if p.UseMask {
+			var b []byte
+			b, err = readline.Password(prompt)
+			value = string(b)
+		} else {
+			value, err = readline.Line(prompt)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/terraform/base.go
+++ b/pkg/cli/terraform/base.go
@@ -1,10 +1,10 @@
 package terraform
 
 import (
-	"github.com/paperspace/paperspace-go"
+	"github.com/Paperspace/paperspace-go"
 )
 
-var SourcePrefix = "github.com/paperspace/gradient-installer"
+var SourcePrefix = "github.com/Paperspace/gradient-installer"
 var SupportedClusterPlatformTypes = []paperspace.ClusterPlatformType{paperspace.ClusterPlatformAWS, paperspace.ClusterPlatformDGX, paperspace.ClusterPlatformMetal}
 
 type PoolType string

--- a/pkg/cli/terraform/commands.go
+++ b/pkg/cli/terraform/commands.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/paperspace/gradient-installer/pkg/cli"
-	"github.com/paperspace/gradient-installer/pkg/cli/config"
+	"github.com/Paperspace/gradient-installer/pkg/cli"
+	"github.com/Paperspace/gradient-installer/pkg/cli/config"
 )
 
 var setupURL = "https://raw.githubusercontent.com/Paperspace/gradient-installer/master/bin/setup"

--- a/pkg/cli/terraform/common.go
+++ b/pkg/cli/terraform/common.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/paperspace/paperspace-go"
+	"github.com/Paperspace/paperspace-go"
 )
 
 type Common struct {


### PR DESCRIPTION
When creating a cluster we need to prompt for container registry credentials so that features like notebook snapshotting are functional.


To run this branch:
1. `brew install go`
2. `git clone git@github.com/Paperspace/gradient-installer.git`
3. `cd gradient-installer`
4. `git checkout feat-container-registry`
5. `go run ./cmd/gradient-installer clusters up`

QA Test Plan:
1. Create a cluster on AWS with a container registry
  (use the container registry info from the `staging-ps-aws cluster` in 1password)
2. Launch a notebook, pip install a package, stop the notebook
3. Restart the same notebook and verify that the same pip package is installed in the container.
4. `go run ./cmd/gradient-installer clusters down <handle>`