### PR TITLE
add checksum global value for gradient-processing secret

### DIFF
--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -89,6 +89,7 @@ resource "helm_release" "gradient_processing" {
             elastic_search_sha = sha256("${var.elastic_search_host}${var.elastic_search_password}${var.elastic_search_port}${var.elastic_search_user}")
             elastic_search_user = var.elastic_search_user
             domain = var.domain
+            gradient_processing_secret_checksum = sha256("${var.cluster_handle}${var.cluster_apikey}")
             global_selector = var.global_selector
             label_selector_cpu = var.label_selector_cpu
             label_selector_gpu = var.label_selector_gpu

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -15,6 +15,7 @@ global:
   logs:
     host: ${logs_host}
   ingressHost: ${domain}
+  gradientProcessingSecretChecksum: ${gradient_processing_secret_checksum}
   serviceNodeSelector:
     paperspace.com/pool-name: ${service_pool_name}
 


### PR DESCRIPTION
This is dependent on chart template changes for 5 other repos to work fully, but this check-in should be safe to go first.

gradient-experiment-watcher
gradient-model-deployment-watcher
gradient-operator-dispatcher
gradient-operator
gradient-tensorboard-watcher

Each of the above repos will have a new deployment template annotation similar to this:

  template:
    metadata:
      annotations:
        {{- if .Values.global.gradientProcessingSecretChecksum }}
        paperspace.com/secret-checksum: {{ .Values.global.gradientProcessingSecretChecksum }}
        {{- end }}

I've checked the behavior of several other api-key secret references, for prometheus ingress, fluent-bit, and the new heartbeat cron job, and they all work appropriately already.

I've tested this locally and it works upon running the following twice in a row:

gradient-installer clusters up cly1a4z06
(run test workloads)
gradient-installer clusters up cly1a4z06 -r
(run test workloads again; previously the would stay in pending even though the cluster would run them)

 