### PR TITLE
bug(metrics): Update the default values for the Pushgateway

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -366,10 +366,9 @@ prometheus:
     nodeSelector:
       paperspace.com/pool-name: ${service_pool_name}
 
-prom-aggregation-gateway:
+prometheus-pushgateway:
   ingress:
-    hostPath:
-      ${domain}: /gateway
+    enabled: false
 
 traefik:
   replicas: 1


### PR DESCRIPTION
Maintain default configuration from the parent chart. Maintain ingress false since no external access is needed.