### PR TITLE
Revert "fix(ps-cloud): add reservations for kubelet to improve node stability CLD-308"

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -307,16 +307,6 @@ resource "rancher2_cluster" "main" {
             max_unavailable_controlplane = "1"
             max_unavailable_worker       = "10%"
         }
-
-        services {
-            kubelet {
-                extra_args = {
-                    "system-reserved" = "cpu=500m,memory=256Mi,ephemeral-storage=5Gi"
-                    "kube-reserved-cgroup" = "/podruntime.slice"
-                    "kube-reserved" = "cpu=500m,memory=256Mi,ephemeral-storage=5Gi"
-                }
-            }
-        }
   }
 }
 

--- a/gradient-ps-cloud/templates/setup-script.tpl
+++ b/gradient-ps-cloud/templates/setup-script.tpl
@@ -6,13 +6,6 @@ until docker ps -a || (( count++ >= 30 )); do echo "Check if docker is up..."; s
 
 usermod -G docker paperspace
 
-mkdir -p /sys/fs/cgroup/pids/podruntime.slice
-mkdir -p /sys/fs/cgroup/hugetlb/podruntime.slice
-mkdir -p /sys/fs/cgroup/cpuset/podruntime.slice
-mkdir -p /sys/fs/cgroup/cpu/podruntime.slice
-mkdir -p /sys/fs/cgroup/memory/podruntime.slice
-mkdir -p /sys/fs/cgroup/systemd/podruntime.slice
-
 cat <<EOL > /etc/docker/daemon.json
 {
     "log-driver": "json-file",


### PR DESCRIPTION
Reverts Paperspace/gradient-installer#139

Free-CPU nodes are too small to actually schedule anything on after making system reservations.