### PR TITLE
fix(traefik/prometheus): adjust traefik and prom reservations if running a public cluster

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -83,6 +83,8 @@ locals {
         "V100"=0,
     }, var.asg_min_sizes)
 
+    is_public_cluster = var.gradient_machine_config == "paperspace-public"
+
     cluster_autoscaler_cloudprovider = "paperspace"
     cluster_autoscaler_enabled = true
     dns_node_selector = var.kind == "multinode" ? {} : { "paperspace.com/pool-name" = "services-small" }

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -245,6 +245,7 @@ resource "null_resource" "check_cluster" {
 module "gradient_processing" {
     source = "../modules/gradient-processing"
     enabled = null_resource.check_cluster.id == "" ? false : true
+    is_public_cluster = local.is_public_cluster
 
     amqp_hostname = var.amqp_hostname
     amqp_port = var.amqp_port

--- a/modules/gradient-processing/input.tf
+++ b/modules/gradient-processing/input.tf
@@ -264,3 +264,9 @@ variable "anti_crypto_miner_regex" {
   description = "Scan for crytpo miner processes using this regex"
   default = ""
 }
+
+variable "is_public_cluster" {
+  description = "designate whether the cluster is a public cluster"
+  type = bool
+  default = false
+}

--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -123,6 +123,7 @@ resource "helm_release" "gradient_processing" {
             elastic_search_port= var.elastic_search_port
             elastic_search_sha = sha256("${var.elastic_search_host}${var.elastic_search_password}${var.elastic_search_port}${var.elastic_search_user}")
             elastic_search_user = var.elastic_search_user
+            is_public_cluster = var.is_public_cluster
             domain = var.domain
             global_selector = var.global_selector
             label_selector_cpu = var.label_selector_cpu

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -267,6 +267,15 @@ kube-prometheus-stack:
     prometheusSpec:
       nodeSelector:
         paperspace.com/pool-name: ${service_pool_name}
+      %{ if is_public_cluster }
+      resources:
+        limits:
+          cpu: 4000m
+          memory: 3Gi
+        requests:
+          cpu: 2000m
+          memory: 1Gi
+      %{ endif }
     ingress:
       hosts:
         - ${domain}
@@ -322,6 +331,16 @@ traefik:
       - 8.8.8.8:53
     persistence:
       storageClass: ${shared_storage_name}
+  %{ endif }
+
+  %{ if is_public_cluster }
+  resources:
+    requests:
+      cpu: 500m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 2048Mi
   %{ endif }
 
 argo:


### PR DESCRIPTION
We moved lower defaults to the processing chart and want to override them here.