### PR TITLE
Update cached images

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -312,7 +312,6 @@ module "gradient_processing" {
         "paperspace/dl-containers:tensorflow1140-py36-cu100-cdnn7-jupyter",
         "paperspace/all-in-one:0.1.0",
         "rapidsai/rapidsai:0.19-cuda11.0-runtime-ubuntu18.04-py3.7",
-        "rapidsai/rapidsai:0.18-cuda11.0-base-ubuntu18.04",
         "nvcr.io/nvidia/pytorch:21.02-py3",
         "jupyter/r-notebook",
         "jupyter/datascience-notebook",

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -300,17 +300,12 @@ module "gradient_processing" {
     cert_manager_enabled = true
     image_cache_enabled = true
     image_cache_list = length(var.image_cache_list) != 0 ? var.image_cache_list : [
-        "ufoym/deepo:all-py27-jupyter",
         "tensorflow/tensorflow:2.4.1-gpu-jupyter",
-        "tensorflow/tensorflow:2.0.0a0-py3-jupyter",
-        "tensorflow/tensorflow:1.5.0-py3",
-        "tensorflow/tensorflow:1.5.0-gpu-py3",
         "paperspace/transformers-gpu:0.4.0",
         "paperspace/gradient-base:tf24-py36-0.10",
         "paperspace/gradient-base:tf115-py36-0.10",
         "paperspace/fastai:2.0-CUDA9.2-fastbook-v0.1.0",
         "paperspace/dl-containers:tensorflow1140-py36-cu100-cdnn7-jupyter",
-        "paperspace/all-in-one:0.1.0",
         "rapidsai/rapidsai:0.19-cuda11.0-runtime-ubuntu18.04-py3.7",
         "nvcr.io/nvidia/pytorch:21.02-py3",
         "jupyter/r-notebook",

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -311,7 +311,7 @@ module "gradient_processing" {
         "paperspace/fastai:2.0-CUDA9.2-fastbook-v0.1.0",
         "paperspace/dl-containers:tensorflow1140-py36-cu100-cdnn7-jupyter",
         "paperspace/all-in-one:0.1.0",
-        "nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda11.0-base-ubuntu18.04",
+        "rapidsai/rapidsai:0.19-cuda11.0-runtime-ubuntu18.04-py3.7",
         "rapidsai/rapidsai:0.18-cuda11.0-base-ubuntu18.04",
         "nvcr.io/nvidia/pytorch:21.02-py3",
         "jupyter/r-notebook",

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -306,7 +306,7 @@ module "gradient_processing" {
         "tensorflow/tensorflow:1.5.0-py3",
         "tensorflow/tensorflow:1.5.0-gpu-py3",
         "paperspace/transformers-gpu:0.4.0",
-        "paperspace/gradient-base:tf24-py38-0.10-small",
+        "paperspace/gradient-base:tf24-py36-0.10",
         "paperspace/gradient-base:tf115-py36-0.10",
         "paperspace/fastai:2.0-CUDA9.2-fastbook-v0.1.0",
         "paperspace/dl-containers:tensorflow1140-py36-cu100-cdnn7-jupyter",


### PR DESCRIPTION
This PR updates cached images to those that satisfy two criteria:
1. Are currently used in a Recommended or All tile in the console
2. Are used with regularity

Diff as follows. 
`>` = currently used in Recommended or All tile in the console
`+` = on list of most pulled containers when starting notebooks


```
        "ufoym/deepo:all-py27-jupyter",
+   >   "tensorflow/tensorflow:2.4.1-gpu-jupyter",
        "tensorflow/tensorflow:2.0.0a0-py3-jupyter",
        "tensorflow/tensorflow:1.5.0-py3",
        "tensorflow/tensorflow:1.5.0-gpu-py3",
+   >   "paperspace/transformers-gpu:0.4.0",
        "paperspace/gradient-base:tf24-py38-0.10-small",
+   >   "paperspace/gradient-base:tf24-py36-0.10",
        "paperspace/gradient-base:tf115-py36-0.10",
+   >   "paperspace/fastai:2.0-CUDA9.2-fastbook-v0.1.0",
+   >   "paperspace/dl-containers:tensorflow1140-py36-cu100-cdnn7-jupyter",
        "paperspace/all-in-one:0.1.0",
        "nvcr.io/nvidia/rapidsai/rapidsai:0.18-cuda11.0-base-ubuntu18.04",
+   >   "rapidsai/rapidsai:0.19-cuda11.0-runtime-ubuntu18.04-py3.7",
+       "rapidsai/rapidsai:0.18-cuda11.0-base-ubuntu18.04",
+   >   "nvcr.io/nvidia/pytorch:21.02-py3",
+   >   "jupyter/r-notebook",
+   >   "jupyter/datascience-notebook",
+   >   "jalfaizy/cv_docker:latest",
```