### PR TITLE
feat(cluster-token): add cluster_authorization_token parameter

### DIFF
--- a/common/common.tf
+++ b/common/common.tf
@@ -38,6 +38,10 @@ variable "cluster_apikey" {
   description = "Gradient cluster API key"
 }
 
+variable "cluster_authorization_token" {
+    description = "Cluster auth token to facilitate secure internal communication between API and processing site"
+}
+
 variable "cluster_handle" {
   description = "Gradient cluster API handle"
 }

--- a/gradient-aws/common.tf
+++ b/gradient-aws/common.tf
@@ -38,6 +38,10 @@ variable "cluster_apikey" {
   description = "Gradient cluster API key"
 }
 
+variable "cluster_authorization_token" {
+    description = "Cluster auth token to facilitate secure internal communication between API and processing site"
+}
+
 variable "cluster_handle" {
   description = "Gradient cluster API handle"
 }

--- a/gradient-aws/main.tf
+++ b/gradient-aws/main.tf
@@ -142,6 +142,7 @@ module "gradient_processing" {
     artifacts_secret_access_key = var.artifacts_secret_access_key
     chart = var.gradient_processing_chart
     cluster_apikey = var.cluster_apikey
+    cluster_authorization_token = var.cluster_authorization_token
     cluster_autoscaler_enabled = true
     cluster_handle = var.cluster_handle
     domain = var.domain

--- a/gradient-aws/tests/main.tf
+++ b/gradient-aws/tests/main.tf
@@ -9,6 +9,7 @@ module "gradient_aws" {
     artifacts_secret_access_key = "artifacts-secret-access-key"
     
     cluster_apikey = "cluster-apikey-from-paperspace-com"
+    cluster_authorization_token = "cluster-authorization-token-from-paperspace.com"
     cluster_handle = "cluster-handle-from-paperspace-com"
     domain = "gradient.mycompany.com"
 

--- a/gradient-metal/common.tf
+++ b/gradient-metal/common.tf
@@ -38,6 +38,10 @@ variable "cluster_apikey" {
   description = "Gradient cluster API key"
 }
 
+variable "cluster_authorization_token" {
+    description = "Cluster auth token to facilitate secure internal communication between API and processing site"
+}
+
 variable "cluster_handle" {
   description = "Gradient cluster API handle"
 }

--- a/gradient-metal/main.tf
+++ b/gradient-metal/main.tf
@@ -82,6 +82,7 @@ module "gradient_processing" {
     artifacts_secret_access_key = var.artifacts_secret_access_key
     chart = var.gradient_processing_chart
     cluster_apikey = var.cluster_apikey
+    cluster_authorization_token = var.cluster_authorization_token
     cluster_autoscaler_autoscaling_groups = var.cluster_autoscaler_autoscaling_groups
     cluster_autoscaler_cloudprovider = var.cluster_autoscaler_cloudprovider
     cluster_autoscaler_enabled = var.cluster_autoscaler_enabled

--- a/gradient-metal/tests/main.tf
+++ b/gradient-metal/tests/main.tf
@@ -7,6 +7,7 @@ module "gradient_metal" {
     artifacts_secret_access_key = "artifacts-secret-access-key"
     
     cluster_apikey = "cluster-apikey-from-paperspace-com"
+    cluster_authorization_token = "cluster-authorization-token-from-paperspace.com"
     cluster_handle = "cluster-handle-from-paperspace-com"
     domain = "gradient.mycompany.com"
 

--- a/gradient-ps-cloud/common.tf
+++ b/gradient-ps-cloud/common.tf
@@ -38,6 +38,10 @@ variable "cluster_apikey" {
   description = "Gradient cluster API key"
 }
 
+variable "cluster_authorization_token" {
+    description = "Cluster auth token to facilitate secure internal communication between API and processing site"
+}
+
 variable "cluster_handle" {
   description = "Gradient cluster API handle"
 }

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -261,6 +261,7 @@ module "gradient_processing" {
   artifacts_secret_access_key        = var.artifacts_secret_access_key
   chart                              = var.gradient_processing_chart
   cluster_apikey                     = var.cluster_apikey
+  cluster_authorization_token        = var.cluster_authorization_token
   cluster_autoscaler_cloudprovider   = "paperspace"
   cluster_autoscaler_enabled         = true
   cluster_autoscaler_delay_after_add = "2m"

--- a/gradient-ps-cloud/tests/main.tf
+++ b/gradient-ps-cloud/tests/main.tf
@@ -7,6 +7,7 @@ module "gradient" {
     artifacts_secret_access_key = "artifacts-secret-access-key"
     
     cluster_apikey = "cluster-apikey-from-paperspace-com"
+    cluster_authorization_token = "cluster-authorization-token-from-paperspace.com"
     cluster_handle = "cluster-handle-from-paperspace-com"
     domain = "gradient.mycompany.com"
 

--- a/modules/gradient-processing/input.tf
+++ b/modules/gradient-processing/input.tf
@@ -45,6 +45,10 @@ variable "cluster_apikey" {
   description = "Gradient cluster apikey"
 }
 
+variable "cluster_authorization_token" {
+    description = "Cluster auth token to facilitate secure internal communication between API and processing site"
+}
+
 variable "cluster_autoscaler_autoscaling_groups" {
   type        = list(any)
   description = "Cluster autoscaler autoscaling groups"

--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -70,6 +70,10 @@ resource "helm_release" "gradient_processing" {
     value = var.cluster_apikey
   }
   set_sensitive {
+    name  = "secrets.clusterAuthorizationToken"
+    value = var.cluster_authorization_token
+  }
+  set_sensitive {
     name  = "secrets.tlsCert"
     value = var.tls_cert
   }

--- a/pkg/cli/terraform/common.go
+++ b/pkg/cli/terraform/common.go
@@ -14,6 +14,7 @@ type Common struct {
 	ArtifactsRegion                string            `json:"artifacts_region,omitempty"`
 	ArtifactsSecretAccessKey       string            `json:"artifacts_secret_access_key"`
 	ClusterAPIKey                  string            `json:"cluster_apikey"`
+	ClusterAuthorizationToken      string            `json:"cluster_authorization_token"`
 	ClusterHandle                  string            `json:"cluster_handle"`
 	Domain                         string            `json:"domain"`
 	LetsEncryptDNSName             string            `json:"letsencrypt_dns_name,omitempty"`
@@ -110,6 +111,9 @@ func (c *Common) IsValid() bool {
 	if c.ClusterAPIKey == "" {
 		return false
 	}
+	if c.ClusterAuthorizationToken == "" {
+		return false
+	}
 	if c.ClusterHandle == "" {
 		return false
 	}
@@ -135,6 +139,7 @@ func (c *Common) UpdateFromCluster(cluster *paperspace.Cluster) {
 	c.ArtifactsSecretAccessKey = cluster.S3Credential.SecretKey
 
 	c.ClusterAPIKey = cluster.APIToken.Key
+	c.ClusterAuthorizationToken = cluster.ClusterAuthorizationToken.Key
 	c.ClusterHandle = cluster.ID
 	c.Domain = cluster.Domain
 	c.Name = strings.ReplaceAll(cluster.Name, " ", "-")

--- a/pkg/cli/terraform/common.go
+++ b/pkg/cli/terraform/common.go
@@ -107,11 +107,7 @@ func (c *Common) IsValid() bool {
 	if !c.HasValidArtifactsStorage() {
 		return false
 	}
-
 	if c.ClusterAPIKey == "" {
-		return false
-	}
-	if c.ClusterAuthorizationToken == "" {
 		return false
 	}
 	if c.ClusterHandle == "" {
@@ -139,7 +135,6 @@ func (c *Common) UpdateFromCluster(cluster *paperspace.Cluster) {
 	c.ArtifactsSecretAccessKey = cluster.S3Credential.SecretKey
 
 	c.ClusterAPIKey = cluster.APIToken.Key
-	c.ClusterAuthorizationToken = cluster.ClusterAuthorizationToken.Key
 	c.ClusterHandle = cluster.ID
 	c.Domain = cluster.Domain
 	c.Name = strings.ReplaceAll(cluster.Name, " ", "-")

--- a/pkg/cli/terraform/common.go
+++ b/pkg/cli/terraform/common.go
@@ -14,7 +14,6 @@ type Common struct {
 	ArtifactsRegion                string            `json:"artifacts_region,omitempty"`
 	ArtifactsSecretAccessKey       string            `json:"artifacts_secret_access_key"`
 	ClusterAPIKey                  string            `json:"cluster_apikey"`
-	ClusterAuthorizationToken      string            `json:"cluster_authorization_token"`
 	ClusterHandle                  string            `json:"cluster_handle"`
 	Domain                         string            `json:"domain"`
 	LetsEncryptDNSName             string            `json:"letsencrypt_dns_name,omitempty"`


### PR DESCRIPTION
Allows a terraform variable to be passed through and set to a secret for the processing chart to load.

Tested by deploying to the public cluster.