### PR TITLE
fix: disable elastic search

### DIFF
--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -140,7 +140,7 @@ resource "helm_release" "gradient_processing" {
       cluster_secret_checksum               = sha256("${var.cluster_handle}${var.cluster_apikey}")
       default_storage_name                  = local.local_storage_name
       efs_provisioner_enabled               = var.shared_storage_type == "efs" || var.local_storage_type == "efs"
-      elastic_search_enabled                = var.elastic_search_password != ""
+      elastic_search_enabled                = false
       elastic_search_host                   = var.elastic_search_host
       elastic_search_index                  = var.elastic_search_index
       elastic_search_port                   = var.elastic_search_port


### PR DESCRIPTION
Its not properly set up and may be causing memory leaks and increased errors on updated fluent-bit.