### PR TITLE
fix(auth): pass the cluster secret through to terraform when using cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Paperspace/gradient-installer
 go 1.14
 
 require (
-	github.com/Paperspace/paperspace-go v0.3.3
+	github.com/Paperspace/paperspace-go v1.0.2
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.9.0
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Paperspace/paperspace-go v0.3.3 h1:lkTpzJtl3ZpPtLCv0JhmY/T7j4n5H2FsEB+bSKzl29g=
-github.com/Paperspace/paperspace-go v0.3.3/go.mod h1:dtV/8NzfKc0mPp8zw6Gu2mUvWL5wvOYp/BV+0oaqoc0=
+github.com/Paperspace/paperspace-go v1.0.2 h1:vwcWBctWknL49lfNMgh08BwggVDKsMO89Wt/j16nH1k=
+github.com/Paperspace/paperspace-go v1.0.2/go.mod h1:dtV/8NzfKc0mPp8zw6Gu2mUvWL5wvOYp/BV+0oaqoc0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/cli/commands/clusters/up.go
+++ b/pkg/cli/commands/clusters/up.go
@@ -473,10 +473,11 @@ func NewClusterUpCommand() *cobra.Command {
 				return fmt.Errorf("Platform '%s' is not currently supported by %s", checkCluster.Platform, cli.Name)
 			}
 
-			// Update cluster to regenerate cluster API key
+			// Update cluster to regenerate cluster API key and cluster secret
 			updateClusterParams := paperspace.ClusterUpdateParams{
-				ID:             id,
-				CreateNewToken: true,
+				ID:                     id,
+				CreateNewToken:         true,
+				CreateNewClusterSecret: true,
 			}
 			cluster, err := client.UpdateCluster(id, updateClusterParams)
 			if err != nil {

--- a/pkg/cli/terraform/common.go
+++ b/pkg/cli/terraform/common.go
@@ -14,6 +14,7 @@ type Common struct {
 	ArtifactsRegion                string            `json:"artifacts_region,omitempty"`
 	ArtifactsSecretAccessKey       string            `json:"artifacts_secret_access_key"`
 	ClusterAPIKey                  string            `json:"cluster_apikey"`
+	ClusterSecret                  string            `json:"cluster_authorization_token"` // TODO: modify the terraform module to use the string cluster_secret
 	ClusterHandle                  string            `json:"cluster_handle"`
 	Domain                         string            `json:"domain"`
 	LetsEncryptDNSName             string            `json:"letsencrypt_dns_name,omitempty"`
@@ -134,6 +135,7 @@ func (c *Common) UpdateFromCluster(cluster *paperspace.Cluster) {
 	c.ArtifactsSecretAccessKey = cluster.S3Credential.SecretKey
 
 	c.ClusterAPIKey = cluster.APIToken.Key
+	c.ClusterSecret = cluster.ClusterSecret
 	c.ClusterHandle = cluster.ID
 	c.Domain = cluster.Domain
 	c.Name = strings.ReplaceAll(cluster.Name, " ", "-")


### PR DESCRIPTION
We added a secret to facilitate secure messaging between the cluster and APIs.