### PR TITLE
fix(nodes): bump service nodes to 8

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -105,7 +105,7 @@ locals {
   prometheus_pool_name             = local.enable_gradient_prometheus_pool == 1 ? "prometheus" : "services-small"
   gradient_lb_count                = var.kind == "multinode" ? 1 : 0
   gradient_main_count              = var.kind == "multinode" ? 3 : 1
-  gradient_service_count           = var.kind == "multinode" ? 4 : 0
+  gradient_service_count           = var.kind == "multinode" ? 8 : 0
   k8s_version                      = var.k8s_version == "" ? "1.16.15" : var.k8s_version
   kubeconfig                       = yamldecode(rancher2_cluster_sync.main.kube_config)
   lb_ips                           = var.kind == "multinode" ? paperspace_machine.gradient_lb.*.public_ip_address : [paperspace_machine.gradient_main[0].public_ip_address]


### PR DESCRIPTION
We run a static number of service nodes. Since moving coredns to service nodes, we dont have enough resources. Bumping to 8 will hopefully be enough.