### PR TITLE
fix(gradient-processing): template volumeController correctly

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -419,6 +419,7 @@ imageCacher:
 
 
 volumeController:
+  enabled: true
   %{ if is_public_cluster }
   resources:
     requests:


### PR DESCRIPTION
On private clusters the whole body of the `volumeController` object is omitted leaving the invalid yaml `volumeController:\n` put a key in there so its always valid