### PR TITLE
chore: use c4 instead of c3

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -166,7 +166,6 @@ locals {
   }
 
   asg_max_sizes = var.gradient_machine_config == "paperspace-public" ? merge(local.base_asg_max_sizes, {
-    "Free-CPU-OLD" = 10,
     "Free-CPU"     = 10,
     "Free-GPU"     = 10,
     "Free-RTX4000" = 10,
@@ -215,7 +214,6 @@ locals {
   }, var.asg_min_sizes)
 
   asg_min_sizes = var.gradient_machine_config == "paperspace-public" ? merge(local.base_asg_min_sizes, {
-    "Free-CPU-OLD"     = 0,
     "Free-CPU"     = 0,
     "Free-GPU"     = 0,
     "Free-RTX4000" = 0,

--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -61,6 +61,9 @@ locals {
     "C3" = {
       type = "cpu"
     },
+    "C4" = {
+      type = "cpu"
+    },
     "C5" = {
       type = "cpu"
     },
@@ -163,6 +166,7 @@ locals {
   }
 
   asg_max_sizes = var.gradient_machine_config == "paperspace-public" ? merge(local.base_asg_max_sizes, {
+    "Free-CPU-OLD" = 10,
     "Free-CPU"     = 10,
     "Free-GPU"     = 10,
     "Free-RTX4000" = 10,
@@ -176,6 +180,7 @@ locals {
   }) : local.base_asg_max_sizes
   base_asg_max_sizes = merge({
     "C3"        = 10,
+    "C4"        = 10,
     "C5"        = 10,
     "C7"        = 10,
     "P4000"     = 10,
@@ -210,6 +215,7 @@ locals {
   }, var.asg_min_sizes)
 
   asg_min_sizes = var.gradient_machine_config == "paperspace-public" ? merge(local.base_asg_min_sizes, {
+    "Free-CPU-OLD"     = 0,
     "Free-CPU"     = 0,
     "Free-GPU"     = 0,
     "Free-RTX4000" = 0,
@@ -223,6 +229,7 @@ locals {
   }) : local.base_asg_min_sizes
   base_asg_min_sizes = merge({
     "C3"        = 0,
+    "C4"        = 0,
     "C5"        = 0,
     "C7"        = 0,
     "P4000"     = 0,

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -122,7 +122,7 @@ cluster-autoscaler:
   image:
     pullPolicy: Always
     repository: paperspace/cluster-autoscaler
-    tag: 1.20-1095a584ce32fde4a48d6f4a38995d01bdb9a205
+    tag: 1.20-c1bf54b37714f2683cb31e3db71e07c39183a2d7
 
   autoscalingGroups:
     %{ for autoscaling_group in cluster_autoscaler_autoscaling_groups }

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -122,7 +122,7 @@ cluster-autoscaler:
   image:
     pullPolicy: Always
     repository: paperspace/cluster-autoscaler
-    tag: 1.20-2ffd4ff5bce27c548ee9b7b0554c78cccca24c80
+    tag: 1.20-1095a584ce32fde4a48d6f4a38995d01bdb9a205
 
   autoscalingGroups:
     %{ for autoscaling_group in cluster_autoscaler_autoscaling_groups }


### PR DESCRIPTION
c3 is too under-powered to run user workloads and gradient background processes.