### PR TITLE
chore(register): add identity resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.14
 
 require (
 	github.com/Paperspace/paperspace-go v1.0.4
+	github.com/aws/aws-sdk-go v1.42.27
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.9.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/manifoldco/promptui v0.7.0
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/pkg/cli/commands/clusters/register.go
+++ b/pkg/cli/commands/clusters/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 	"os"
@@ -99,10 +100,8 @@ func ClusterRegister(client *paperspace.Client, createFilePath string) (string, 
 			artifactsSecretAccessKeyPrompt.Value,
 			region,
 		)
-
 		if err != nil {
-			println(fmt.Sprintf("Unable to validate AWS identity from credentails: %s", err))
-			return "", err
+			return "", errors.New("Unable to validate your AWS identity from the specified credentials.")
 		} else {
 			println(fmt.Sprintf("AWS Identity is for: %s", arn))
 		}


### PR DESCRIPTION
Thought it would be nice to have some feedback about whether your credentials work.

This is also ahead of #252 and #253 where I was thinking we would optionally allow clients to create the artifact buckets through our installer instead of requiring it already exist.

Happy Path:
<img width="526" alt="Screen Shot 2022-01-04 at 7 53 56 PM" src="https://user-images.githubusercontent.com/95641952/148144242-e34f60e5-c13f-4545-a866-1fa1cd6a0cd1.png">

Sad Path:
<img width="1022" alt="Screen Shot 2022-01-04 at 7 54 48 PM" src="https://user-images.githubusercontent.com/95641952/148144264-300d7bfa-50ba-436a-b24e-e53996a9c46c.png">

