### PR TITLE
chore(gradient-processing): overrides for csi-provisioner

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -136,6 +136,7 @@ ceph-csi-rbd:
         cpu: 500m
         memory: 256Mi
     %{ endif }
+%{ endif }
 
 cluster-autoscaler:
   enabled: ${cluster_autoscaler_enabled}

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -121,20 +121,20 @@ ceph-csi-rbd:
     resources:
       requests:
         cpu: 500m
-        memory: 2Gi
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 2Gi
     %{ endif }
   csi-resizer:
     %{ if is_public_cluster }
     resources:
       requests:
         cpu: 500m
-        memory: 2Gi
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 2Gi
     %{ endif }
 %{ endif }
 

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -115,7 +115,6 @@ ceph-csi-rbd:
   provisioner:
     nodeSelector:
       paperspace.com/pool-name: ${service_pool_name}
-  csi-provisioner:
     image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
     %{ if is_public_cluster }
     resources:
@@ -126,7 +125,7 @@ ceph-csi-rbd:
         cpu: 500m
         memory: 2Gi
     %{ endif }
-  csi-resizer:
+  resizer:
     %{ if is_public_cluster }
     resources:
       requests:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -95,6 +95,7 @@ ceph-csi-cephfs:
     nodeSelector:
       paperspace.com/pool-name: ${service_pool_name}
 
+# https://github.com/kubernetes-csi/external-provisioner/releases
 %{ if length(rbd_storage_config) != 0 }
 ceph-csi-rbd:
   enabled: true
@@ -114,7 +115,27 @@ ceph-csi-rbd:
   provisioner:
     nodeSelector:
       paperspace.com/pool-name: ${service_pool_name}
-%{ endif }
+  csi-provisioner:
+    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+    %{ if is_public_cluster }
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    %{ endif }
+  csi-resizer:
+    %{ if is_public_cluster }
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    %{ endif }
 
 cluster-autoscaler:
   enabled: ${cluster_autoscaler_enabled}


### PR DESCRIPTION
The `ceph-csi-rbd-provisioner` has been stuck in a crashbackoffloop on the public cluster because two of the containers consistently OOM during boot.