### PR TITLE
chore(gds): bump mem for node state

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -196,6 +196,15 @@ cluster-autoscaler:
 dispatcher:
   config:
     apiAddress: ${dispatcher_host}
+    %{ if is_public_cluster }
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 250m
+        memory: 800Mi
+    %{ endif }
 
 
 efs-provisioner:


### PR DESCRIPTION
After testing in staging, would like to bump the memory limit a bit.