### PR TITLE
chore(gradient-installer): disable special nodes

### DIFF
--- a/gradient-ps-cloud/input.tf
+++ b/gradient-ps-cloud/input.tf
@@ -103,7 +103,12 @@ variable "machine_storage_admin" {
 
 variable "gradient_admin_vm_enabled" {
   description = "gradient admin public box is enabled"
-  default     = true
+  default     = false
+}
+
+variable "gradient_workspace_vm_enabled" {
+  description = "gradient workspace job box is enabled"
+  default     = false
 }
 
 variable "machine_storage_service" {

--- a/gradient-ps-cloud/special_nodes.tf
+++ b/gradient-ps-cloud/special_nodes.tf
@@ -1,5 +1,5 @@
 resource "paperspace_script" "gradient_machine_workspace" {
-  count       = var.gradient_admin_vm_enabled ? 1 : 0
+  count       = var.gradient_workspace_vm_enabled ? 1 : 0
   name        = "Gradient Workspace Controller Node Setup"
   description = "Gradient Workspace Controller Node Script"
   script_text = templatefile("${path.module}/templates/setup-script.tpl", {
@@ -18,7 +18,7 @@ resource "paperspace_script" "gradient_machine_workspace" {
 }
 
 resource "paperspace_machine" "gradient_workspace_node" {
-  count = var.gradient_admin_vm_enabled ? 1 : 0
+  count = var.gradient_workspace_vm_enabled ? 1 : 0
   depends_on = [
     paperspace_script.gradient_machine_workspace,
     tls_private_key.ssh_key,


### PR DESCRIPTION
Staging and production are in a bit of a weird state as of today's upgrades. I want to update them with this release, disabling these boxes and re-enabling them after. 

Fixing a var as well.