### PR TITLE
hotfix(gradient-installer): storage class templating

### DIFF
--- a/modules/gradient-processing/input.tf
+++ b/modules/gradient-processing/input.tf
@@ -366,7 +366,7 @@ variable "victoria_metrics_vmsingle_service_endpoint" {
 variable "victoria_metrics_vmcluster_enabled" {
   description = "Is VMCluster Mode Enabled?"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "victoria_metrics_vmcluster_service_endpoint" {

--- a/modules/gradient-processing/input.tf
+++ b/modules/gradient-processing/input.tf
@@ -366,7 +366,7 @@ variable "victoria_metrics_vmsingle_service_endpoint" {
 variable "victoria_metrics_vmcluster_enabled" {
   description = "Is VMCluster Mode Enabled?"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "victoria_metrics_vmcluster_service_endpoint" {

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -448,7 +448,7 @@ victoria-metrics-k8s-stack:
         storage:
           volumeClaimTemplate:
             spec:
-              storageClassName: "gradient-processing-rbd"
+              storageClassName: "${metrics_storage_class}"
             %{ if is_public_cluster }
               resources:
                 requests:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -441,7 +441,7 @@ victoria-metrics-k8s-stack:
       storage:
         volumeClaimTemplate:
           spec:
-            storageClassName: "${metrics_storage_class}"
+            storageClassName: ${metrics_storage_class}
     ingress:
       select:
         hosts:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -434,7 +434,12 @@ victoria-metrics-k8s-stack:
         nodeSelector:
           paperspace.com/pool-name: ${prometheus_pool_name}
         storage:
-          storageClassName: "gradient-processing-local"
+          volumeClaimTemplate:
+            spec:
+              storageClassName: "gradient-processing-local"
+              resources:
+                requests:
+                  storage: 2Gi
       vmstorage:
         replicaCount: ${vm_storage_replica_count}
         storageDataPath: "/vm-data"

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -442,11 +442,6 @@ victoria-metrics-k8s-stack:
         volumeClaimTemplate:
           spec:
             storageClassName: "${metrics_storage_class}"
-      %{ if is_public_cluster }
-        resources:
-          requests:
-            storage: 100Gi
-      %{ endif }
     ingress:
       select:
         hosts:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -439,12 +439,14 @@ victoria-metrics-k8s-stack:
       nodeSelector:
         paperspace.com/pool-name: ${prometheus_pool_name}
       storage:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: "${metrics_storage_class}"
       %{ if is_public_cluster }
         resources:
           requests:
             storage: 100Gi
       %{ endif }
-        storageClassName: "${metrics_storage_class}"
     ingress:
       select:
         hosts:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -427,26 +427,28 @@ victoria-metrics-k8s-stack:
         
   vmcluster:
     enabled: ${enable_victoria_metrics_vm_cluster}
-    vmselect:
-       replicaCount: ${vm_select_replica_count}
-       nodeSelector:
-         paperspace.com/pool-name: ${prometheus_pool_name}
-       storage:
-         storageClassName: "gradient-processing-local"
-    vmstorage:
-      replicaCount: ${vm_storage_replica_count}
-      storageDataPath: "/vm-data"
-      nodeSelector:
-        paperspace.com/pool-name: ${prometheus_pool_name}
-      storage:
-        volumeClaimTemplate:
-          spec:
-            storageClassName: "gradient-processing-rbd"
-          %{ if is_public_cluster }
-            resources:
-              requests:
-                storage: 100Gi
-          %{ endif }
+    spec:
+      retentionPeriod: "2"
+      vmselect:
+        replicaCount: ${vm_select_replica_count}
+        nodeSelector:
+          paperspace.com/pool-name: ${prometheus_pool_name}
+        storage:
+          storageClassName: "gradient-processing-local"
+      vmstorage:
+        replicaCount: ${vm_storage_replica_count}
+        storageDataPath: "/vm-data"
+        nodeSelector:
+          paperspace.com/pool-name: ${prometheus_pool_name}
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: "gradient-processing-rbd"
+            %{ if is_public_cluster }
+              resources:
+                requests:
+                  storage: 100Gi
+            %{ endif }
     ingress:
       select:
         hosts:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -444,9 +444,7 @@ victoria-metrics-k8s-stack:
           requests:
             storage: 100Gi
       %{ endif }
-        volumeClaimTemplate:
-          spec:
-            storageClassName: "${metrics_storage_class}"
+        storageClassName: "${metrics_storage_class}"
     ingress:
       select:
         hosts:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -441,7 +441,12 @@ victoria-metrics-k8s-stack:
       storage:
         volumeClaimTemplate:
           spec:
-            storageClassName: ${metrics_storage_class}
+            storageClassName: "gradient-processing-rbd"
+          %{ if is_public_cluster }
+            resources:
+              requests:
+                storage: 100Gi
+          %{ endif }
     ingress:
       select:
         hosts:


### PR DESCRIPTION
Templating was originally:
```
                  vmcluster:
                    enabled: true
                    vmselect:
                       replicaCount: 2
                       nodeSelector:
                         paperspace.com/pool-name: prometheus
                       storage:
                         storageClassName: "gradient-processing-local"
                    vmstorage:
                      replicaCount: 2
                      storageDataPath: "/vm-data"
                      nodeSelector:
                        paperspace.com/pool-name: prometheus
                      storage:
                      
                        resources:
                          requests:
                            storage: 100Gi
                      
                        volumeClaimTemplate:
                          spec:
                            storageClassName: "gradient-processing-rbd"
```

And didn't take affect correctly.