### PR TITLE
chore(victoria): lowering memory utilization for cache

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -454,7 +454,7 @@ victoria-metrics-k8s-stack:
         extraArgs:
           search.maxUniqueTimeseries: "6000000"
           memory.allowedPercent: 45.0
-          retentionPeriod: 2d
+          retentionPeriod: 2w
         replicaCount: ${vm_storage_replica_count}
         storageDataPath: "/vm-data"
         nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -428,6 +428,7 @@ victoria-metrics-k8s-stack:
   vmcluster:
     enabled: ${enable_victoria_metrics_vm_cluster}
     spec:
+      retentionPeriod: "2w"
       vminsert:
         extraArgs:
           maxLabelsPerTimeseries: "70"
@@ -453,7 +454,6 @@ victoria-metrics-k8s-stack:
         extraArgs:
           search.maxUniqueTimeseries: "6000000"
           memory.allowedPercent: "45.0"
-          retentionPeriod: 2w
         replicaCount: ${vm_storage_replica_count}
         storageDataPath: "/vm-data"
         nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -453,6 +453,8 @@ victoria-metrics-k8s-stack:
       vmstorage:
         extraArgs:
           search.maxUniqueTimeseries: "6000000"
+          memory.allowedPercent: 45.0
+          retentionPeriod: 2d
         replicaCount: ${vm_storage_replica_count}
         storageDataPath: "/vm-data"
         nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -469,6 +469,9 @@ victoria-metrics-k8s-stack:
                   storage: 100Gi
             %{ endif }
         resources:
+          requests:
+            cpu: "1"
+            memory: 1Gi
           limits:
             cpu: "4"
             memory: 10Gi

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -428,7 +428,6 @@ victoria-metrics-k8s-stack:
   vmcluster:
     enabled: ${enable_victoria_metrics_vm_cluster}
     spec:
-      retentionPeriod: "2"
       vminsert:
         extraArgs:
           maxLabelsPerTimeseries: "70"

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -453,7 +453,7 @@ victoria-metrics-k8s-stack:
       vmstorage:
         extraArgs:
           search.maxUniqueTimeseries: "6000000"
-          memory.allowedPercent: 45.0
+          memory.allowedPercent: "45.0"
           retentionPeriod: 2w
         replicaCount: ${vm_storage_replica_count}
         storageDataPath: "/vm-data"


### PR DESCRIPTION
victoria's vmstorage cache is running hot!

```
kubectl top pod vmstorage-gradient-processing-victoria-metrics-0 
NAME                                               CPU(cores)   MEMORY(bytes)   
vmstorage-gradient-processing-victoria-metrics-0   617m         9108Mi          
kubectl top pod vmstorage-gradient-processing-victoria-metrics-1
NAME                                               CPU(cores)   MEMORY(bytes)   
vmstorage-gradient-processing-victoria-metrics-1   619m         9458Mi 
```

```
 -memory.allowedPercent float
     Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from OS page cache which will result in higher disk IO usage (default 60)
```

Ref here: https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#list-of-command-line-flags-for-vmstorage