### PR TITLE
chore(victoria): lower request barrier

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -469,8 +469,8 @@ victoria-metrics-k8s-stack:
             %{ endif }
         resources:
           requests:
-            cpu: "1"
-            memory: 1Gi
+            cpu: "0.5"
+            memory: 0.5Gi
           limits:
             cpu: "4"
             memory: 10Gi


### PR DESCRIPTION
Need to lower the barrier of entry for this because staging isn't able to schedule a second storage node.