### PR TITLE
fix(victoria): prod hotfixes vmagent

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -528,12 +528,6 @@ victoria-metrics-k8s-stack:
           memory: 4Gi
       %{ endif }
 
-  kubelet:
-    enabled: true
-    spec:
-      interval: 20s
-      scrapeTimeout: 10s
-
 traefik:
   replicas: ${lb_count}
   nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,8 +512,6 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
-    extraArgs:
-      promscrape.streamParse: false
     spec:
       externalLabels:
         cluster: ${cluster_handle}
@@ -529,11 +527,6 @@ victoria-metrics-k8s-stack:
           memory: 4Gi
       %{ endif }
 
-  kubelet:
-    enabled: true
-    spec:
-      interval: 20s
-      scrapeTimeout: 10s
 traefik:
   replicas: ${lb_count}
   nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -513,8 +513,6 @@ victoria-metrics-k8s-stack:
 
   vmagent:
     enabled: true
-    extraArgs:
-      promscrape.streamParse: false
     spec:
       externalLabels:
         cluster: ${cluster_handle}
@@ -533,8 +531,8 @@ victoria-metrics-k8s-stack:
   kubelet:
     enabled: true
     spec:
-      interval: 10s
-      scrapeTimeout: 9s
+      interval: 20s
+      scrapeTimeout: 10s
 
 traefik:
   replicas: ${lb_count}

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,7 +512,7 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
-    enabled: false
+    enabled: true
     extraArgs:
       promscrape.streamParse: false
     spec:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -514,7 +514,7 @@ victoria-metrics-k8s-stack:
   vmagent:
     enabled: true
     extraArgs:
-      promscrape.streamParse: false
+      promscrape.streamParse: true
     spec:
       externalLabels:
         cluster: ${cluster_handle}
@@ -533,8 +533,9 @@ victoria-metrics-k8s-stack:
   kubelet:
     enabled: true
     spec:
-      interval: 20s
-      scrapeTimeout: 10s
+      interval: 10s
+      scrapeTimeout: 9s
+
 traefik:
   replicas: ${lb_count}
   nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -528,6 +528,12 @@ victoria-metrics-k8s-stack:
           memory: 4Gi
       %{ endif }
 
+  kubelet:
+    enabled: true
+    spec:
+      interval: 20s
+      scrapeTimeout: 10s
+
 traefik:
   replicas: ${lb_count}
   nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,6 +512,8 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
+    extraArgs:
+      promscrape.streamParse: false
     spec:
       externalLabels:
         cluster: ${cluster_handle}
@@ -530,8 +532,8 @@ victoria-metrics-k8s-stack:
   kubelet:
     enabled: true
     spec:
-      interval: 10s
-      scrapeTimeout: 6s
+      interval: 20s
+      scrapeTimeout: 10s
 traefik:
   replicas: ${lb_count}
   nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,7 +512,7 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
-    enable: false
+    enable: true
     extraArgs:
       promscrape.streamParse: false
     spec:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,6 +512,9 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
+    enable: false
+    extraArgs:
+      promscrape.streamParse: false
     spec:
       externalLabels:
         cluster: ${cluster_handle}
@@ -527,6 +530,11 @@ victoria-metrics-k8s-stack:
           memory: 4Gi
       %{ endif }
 
+  kubelet:
+    enabled: true
+    spec:
+      interval: 20s
+      scrapeTimeout: 10s
 traefik:
   replicas: ${lb_count}
   nodeSelector:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,7 +512,7 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
-    enable: true
+    enabled: false
     extraArgs:
       promscrape.streamParse: false
     spec:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -512,9 +512,9 @@ victoria-metrics-k8s-stack:
 
 
   vmagent:
-    enabled: true
+    enabled: false
     extraArgs:
-      promscrape.streamParse: true
+      promscrape.streamParse: false
     spec:
       externalLabels:
         cluster: ${cluster_handle}


### PR DESCRIPTION
Good fun, my determination is that lowering a kubelet scrape interval "too" low will additionally lower the `cadvisor` scrape interval (they're bundled). Which is fine in theory, but with streamParse enabled it looks like scrape requests were timing out, specifically to `kube-state-metrics`. I've seen non-related job scrapes in prometheus break other job scrapes, but this was a weird thing.