### PR TITLE
Revert "chore: bump image pull concurrency"

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -563,7 +563,7 @@ argo-rollouts:
 imageCacher:
   enabled: true
   config:
-    maxParallelism: 30
+    maxParallelism: 10
     images: ${image_cache_list}
 %{ endif }
 


### PR DESCRIPTION
This reverts commit d315cf2b1e163d23ee4531598c084bc1c31a8716.