### PR TITLE
chore(ps-cloud): disable workspace vm

### DIFF
--- a/gradient-ps-cloud/input.tf
+++ b/gradient-ps-cloud/input.tf
@@ -112,7 +112,7 @@ variable "gradient_admin_vm_enabled" {
 
 variable "gradient_workspace_vm_enabled" {
   description = "gradient workspace job box is enabled"
-  default     = true
+  default     = false
 }
 
 variable "machine_storage_service" {


### PR DESCRIPTION
workspace downloads are now on init containers so having a special worker doesn't improve scheduling time any more