### PR TITLE
fix(ps-cloud): remove gcr mirror PLA-1516

### DIFF
--- a/gradient-ps-cloud/templates/setup-script.tpl
+++ b/gradient-ps-cloud/templates/setup-script.tpl
@@ -34,7 +34,7 @@ cat <<EOL > /etc/docker/daemon.json
         }
     },
 %{ endif ~}
-    "registry-mirrors": ["${registry_mirror}", "https://mirror.gcr.io"]
+    "registry-mirrors": ["${registry_mirror}"]
 }
 EOL
 


### PR DESCRIPTION
Having an outside the data center fall back can cause issues with our internal internet.