### PR TITLE
fix(container-registry-mirror): service type was incorrect in the chart

### DIFF
--- a/modules/container-registry-mirror/files/docker-registry-mirror.yaml.tpl
+++ b/modules/container-registry-mirror/files/docker-registry-mirror.yaml.tpl
@@ -31,6 +31,9 @@ persistence:
     existingClaim: ${pvc.existing_claim}
 %{ endif }
 
+# this should be the default, its a bug in the chart and prevents scheduling more than one instance per node
+service:
+    type: ClusterIP
 
 ingress:
   enabled: true


### PR DESCRIPTION
The chart's default of NodePort isn't needed and causes issues running multiple replicas on a single node.