### PR TITLE
fix(graphcore-coredns-rke2): Ensure coredns only runs on services-small

### DIFF
--- a/gradient-metal-gc/ansible/roles/gradient_common/tasks/install_kubelet_config.yml
+++ b/gradient-metal-gc/ansible/roles/gradient_common/tasks/install_kubelet_config.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create containerd cgroups
+  ansible.builtin.file:
+    path: '/etc/rancher/rke2'
+    state: directory
+    mode: 0755
+
 - name: Install Gradient RKE2 KubeletConfig File
   copy:
     dest: /etc/rancher/rke2/kubelet-config.yaml

--- a/gradient-metal-gc/ansible/roles/gradient_control_node/defaults/main.yml
+++ b/gradient-metal-gc/ansible/roles/gradient_control_node/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+rke2_coredns_replica_count: 2

--- a/gradient-metal-gc/ansible/roles/gradient_control_node/tasks/main.yml
+++ b/gradient-metal-gc/ansible/roles/gradient_control_node/tasks/main.yml
@@ -18,6 +18,24 @@
   ansible.builtin.include_tasks: install_rke2_on_other_servers.yml
   when: inventory_hostname in groups['gradient_control_nodes'][1:]
 
+- name: Install rke2-coredns HelmConfigChart
+  copy:
+    dest: /var/lib/rancher/rke2/server/manifests/rke2-coredns-config.yaml
+    content: |
+      apiVersion: helm.cattle.io/v1
+      kind: HelmChartConfig
+      metadata:
+        name: rke2-coredns
+        namespace: kube-system
+      spec:
+        valuesContent: |-
+          autoscaler:
+            enabled: false
+          replicaCount: {{ rke2_coredns_replica_count }}
+          nodeSelector:
+            paperspace.com/pool-name: services-small
+  when: inventory_hostname in groups['gradient_control_nodes'][0]
+
 - name: Install Terraform
   ansible.builtin.include_tasks: install_terraform.yml
 


### PR DESCRIPTION
Running these on user nodes means that resource starvation can effect more than a single user. These should be scheduled on the services nodes.

I have also notice that rancher tunes the scale params way to high by default. There are like 20 running on our cluster. The coredns docs say you need 2 min for ha, and to add another for every ~250 nodes.

Configure Rancher to only run these on the services nodes