### PR TITLE
fix: run services on service nodes

### DIFF
--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -42,6 +42,21 @@ resource "helm_release" "cert_manager" {
       "nodeSelector" = {
         "paperspace.com/pool-name" = var.service_pool_name
       }
+      "webhook" = {
+        "nodeSelector" = {
+          "paperspace.com/pool-name" = var.service_pool_name
+        }
+      }
+      "cainjector" = {
+        "nodeSelector" = {
+          "paperspace.com/pool-name" = var.service_pool_name
+        }
+      }
+      "startupapicheck" = {
+        "nodeSelector" = {
+          "paperspace.com/pool-name" = var.service_pool_name
+        }
+      }
     })
   ]
 }
@@ -52,6 +67,14 @@ resource "helm_release" "metrics_server" {
   repository = "https://kubernetes-sigs.github.io/metrics-server"
   chart      = "metrics-server"
   version    = var.metrics_server_version
+  
+  values = [
+    yamlencode({
+      "nodeSelector" = {
+        "paperspace.com/pool-name" = var.service_pool_name
+      }
+    })
+  ]
 }
 
 resource "random_password" "nats_token" {

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -425,6 +425,8 @@ victoria-metrics-k8s-stack:
       vminsert:
         extraArgs:
           maxLabelsPerTimeseries: "70"
+        nodeSelector:
+          paperspace.com/pool-name: ${service_pool_name}
       vmselect:
         resources:
         %{ if is_public_cluster }
@@ -694,6 +696,9 @@ nodeHealthChecks:
 
 nats:
   enabled: true
+
+  nodeSelector:
+    paperspace.com/pool-name: ${service_pool_name}
 
   auth:
     enabled: true


### PR DESCRIPTION
Several services were found to be running on user worker nodes which causes instability in user workloads and in the mission critical services.

* nats
* cainjector
* metrics-server
* vminsert