### PR TITLE
fix: nats replicas and jetstream

### DIFF
--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -706,17 +706,18 @@ nats:
     enabled: true
     replicas: 3
   
-  jetstream:
-    enabled: true
-
-    memStorage:
-      enabled: false
-      size: 10Gi
-
-    fileStorage:
+  nats:
+    jetstream:
       enabled: true
-      size: 350Gi
-      storageClassName: ${nats_storage_class}
+
+      memStorage:
+        enabled: false
+        size: 10Gi
+
+      fileStorage:
+        enabled: true
+        size: 350Gi
+        storageClassName: ${nats_storage_class}
 
 telemetry:
   enabled: true

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -702,22 +702,21 @@ nats:
     enabled: true
     token: "${nats_token}"
 
-  nats:
-    cluster:
-      enabled: true
-      replicas: 3
+  cluster:
+    enabled: true
+    replicas: 3
   
-    jetstream:
+  jetstream:
+    enabled: true
+
+    memStorage:
+      enabled: false
+      size: 10Gi
+
+    fileStorage:
       enabled: true
-
-      memStorage:
-        enabled: false
-        size: 10Gi
-
-      fileStorage:
-        enabled: true
-        size: 350Gi
-        storageClassName: ${nats_storage_class}
+      size: 350Gi
+      storageClassName: ${nats_storage_class}
 
 telemetry:
   enabled: true


### PR DESCRIPTION
The nats cluster configuration was nested under an extra `nats` key and being ignored