### PR TITLE
fix(ps-cloud): put victoria metrics cluster on multiple nodes SIT-255

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -285,12 +285,12 @@ locals {
   enable_gradient_lb               = var.kind == "multinode" ? 1 : 0
   enable_gradient_prometheus_pool  = local.is_public_cluster ? 1 : 0
   gradient_prometheus_pool_count   = local.enable_gradient_prometheus_pool == 1 ? 1 : 0
-  prometheus_pool_name             = local.enable_gradient_prometheus_pool == 1 ? "prometheus" : "services-small"
+  prometheus_pool_name             = "services-small"
   gradient_lb_count                = var.kind == "multinode" ? 2 : 0
   gradient_main_count              = local.is_public_cluster ? 5 : var.kind == "multinode" ? 3 : 1 # etcd or etcd + api-server. 1, 3, and 5 are the only valid configs
 
   gradient_controlplane_count = local.is_public_cluster ? 5 : 0 # kube api-server. scale horizontally
-  gradient_service_count      = var.kind == "multinode" ? 5 : 0 # generic worker pool for gradient servces, scale horizontally
+  gradient_service_count      = var.kind == "multinode" ? 8 : 0 # generic worker pool for gradient servces, scale horizontally
   k8s_version                 = var.k8s_version == "" ? "1.20.15" : var.k8s_version
   kubeconfig                  = yamldecode(rancher2_cluster_sync.main.kube_config)
   lb_ips                      = var.kind == "multinode" ? paperspace_machine.gradient_lb.*.public_ip_address : [paperspace_machine.gradient_main[0].public_ip_address]

--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -12,8 +12,8 @@ locals {
   }
 
   # Use shared configuration for local configuration
-  local_storage_config = local.shared_storage_config
-  local_storage_name   = local.shared_storage_name
+  local_storage_config  = local.shared_storage_config
+  local_storage_name    = local.shared_storage_name
   local_storage_secrets = local.shared_storage_secrets
 
   rbd_storage_config = var.rbd_storage_config == "" ? {} : jsondecode(var.rbd_storage_config)
@@ -67,7 +67,7 @@ resource "helm_release" "metrics_server" {
   repository = "https://kubernetes-sigs.github.io/metrics-server"
   chart      = "metrics-server"
   version    = var.metrics_server_version
-  
+
   values = [
     yamlencode({
       "nodeSelector" = {
@@ -120,7 +120,7 @@ resource "helm_release" "gradient_processing" {
   }
 
   set {
-    name = "traefik.timeouts.forwarding.responseHeaderTimeout"
+    name  = "traefik.timeouts.forwarding.responseHeaderTimeout"
     value = var.forwarding_response_header_timeout
   }
 
@@ -231,8 +231,8 @@ resource "helm_release" "gradient_processing" {
 
       enable_victoria_metrics_vm_single                   = var.victoria_metrics_vmsingle_enabled
       enable_victoria_metrics_vm_cluster                  = var.victoria_metrics_vmcluster_enabled
-      vm_select_replica_count                             = var.cluster_handle == "clw6rxq2s" ? 1 : var.victoria_metrics_vmcluster_vmselect_replicacount
-      vm_storage_replica_count                            = var.cluster_handle == "clw6rxq2s" ? 1 : var.victoria_metrics_vmcluster_vmstorage_replicacount
+      vm_select_replica_count                             = var.victoria_metrics_vmcluster_vmselect_replicacount
+      vm_storage_replica_count                            = var.victoria_metrics_vmcluster_vmstorage_replicacount
       ipu_controller_server                               = var.ipu_controller_server
       ipu_model_cache_pvc_name                            = var.ipu_model_cache_pvc_name
       ipuof_vipu_api_host                                 = var.ipuof_vipu_api_host

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -425,6 +425,24 @@ victoria-metrics-k8s-stack:
           maxLabelsPerTimeseries: "70"
         nodeSelector:
           paperspace.com/pool-name: ${service_pool_name}
+        resources:
+        %{ if is_public_cluster }
+          limits:
+            cpu: "2"
+            memory: 2Gi
+        %{ else }
+          limits:
+            cpu: "1"
+            memory: 1Gi
+        %{ endif }
+        %{ if is_public_cluster }
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        %{ endif }
       vmselect:
         resources:
         %{ if is_public_cluster }
@@ -447,6 +465,14 @@ victoria-metrics-k8s-stack:
         replicaCount: ${vm_select_replica_count}
         nodeSelector:
           paperspace.com/pool-name: ${prometheus_pool_name}
+        %{ if is_public_cluster }
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        %{ endif }
         storage:
           volumeClaimTemplate:
             spec:
@@ -460,6 +486,14 @@ victoria-metrics-k8s-stack:
           memory.allowedPercent: "75.0"
         replicaCount: ${vm_storage_replica_count}
         storageDataPath: "/vm-data"
+        %{ if is_public_cluster }
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        %{ endif }
         nodeSelector:
           paperspace.com/pool-name: ${prometheus_pool_name}
         storage:
@@ -472,12 +506,21 @@ victoria-metrics-k8s-stack:
                   storage: 500Gi
             %{ endif }
         resources:
+        %{ if is_public_cluster }
+          requests:
+            cpu: "1"
+            memory: 4Gi
+          limits:
+            cpu: "6"
+            memory: 20Gi
+        %{ else }
           requests:
             cpu: "1"
             memory: 0.5Gi
           limits:
-            cpu: 6
-            memory: 40Gi
+            cpu: "2"
+            memory: 1Gi
+        %{ endif }
     ingress:
       select:
         hosts:


### PR DESCRIPTION
To improve reliability and scalability. We would in particular like to schedule more `vmstorage` nodes to take advantage of sharding.

Now that we have more nodes, I have also added anti affinity rules to prevent co-scheduling thus improving resilience.

This pr does not remove the current `prometheus` C9 node so that I can move the pods gracefully first. The terraform would rip out the node before the scheduler labels are updated thus the cluster would have nowhere to schedule vmselect and vmstorage pods until much later causing unnecessary downtime. I will remove that node at a later time when nothing is running on it.