### PR TITLE
chore: victoria ingress rewrite rule

### DIFF
--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -227,6 +227,7 @@ resource "helm_release" "gradient_processing" {
       gradient_metrics_adapter_endpoint = local.gradient_metrics_adapter_endpoint
       gradient_metrics_port             = var.metrics_port
       gradient_metrics_path             = var.metrics_path
+      gradient_metrics_service_name     = var.metrics_service_name
 
       nats_storage_class = var.nats_storage_class
       nats_token         = random_password.nats_token.result

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -39,8 +39,8 @@ global:
   # to the desired victoria destination. Reuse these for our rewrite ingress rule.
   metrics:
     ingressHost: ${domain}
-    rewriteTarget: ${metrics_path}
-    serviceName: ${metrics_service_name}-rewrite
+    rewriteTarget: ${gradient_metrics_path}
+    serviceName: ${gradient_metrics_service_name}-rewrite
 
   defaultStorageName: ${default_storage_name}
   sharedStorageName: ${shared_storage_name}

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -35,6 +35,13 @@ global:
   dispatcherServerApiAddress: ${dispatcher_host}:443
   clusterAPIHost: ${cluster_api_host}:443
 
+  # We already define metrics path + service which correctly point...
+  # to the desired victoria destination. Reuse these for our rewite ingress rule.
+  metrics:
+    ingressHost: ${domain}
+    rewriteTarget: ${metrics_path}
+    serviceName: ${metrics_service_name}-rewrite
+
   defaultStorageName: ${default_storage_name}
   sharedStorageName: ${shared_storage_name}
   storage:

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -36,7 +36,7 @@ global:
   clusterAPIHost: ${cluster_api_host}:443
 
   # We already define metrics path + service which correctly point...
-  # to the desired victoria destination. Reuse these for our rewite ingress rule.
+  # to the desired victoria destination. Reuse these for our rewrite ingress rule.
   metrics:
     ingressHost: ${domain}
     rewriteTarget: ${metrics_path}


### PR DESCRIPTION
We're configuring a new rule for our internal apis to interact with for customer metrics.

This new config allows us to provision the new ingress within gradient processing.